### PR TITLE
Fixed consumption calculation

### DIFF
--- a/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
+++ b/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
@@ -249,16 +249,17 @@ public:
 
 class MeterChannel : public Channel<MeterList1,EmptyList,List4,PEERS_PER_CHANNEL>, public Alarm {
 
-  uint32_t counter;
-  uint32_t power;
-  Message  msg;
-  uint8_t  msgcnt;
-  bool     boot;
-
+  const uint32_t maxVal = 838860700;
+  uint64_t counterSum;
+  volatile uint32_t counter; // declare as volatile because of usage withing interrupt
+  Message     msg;
+  uint8_t     msgcnt;
+  bool        boot;
+  
 private:
 
 public:
-  MeterChannel () : Channel(), Alarm(MSG_CYCLE), counter(0), power(0), msgcnt(0), boot(true) {}
+  MeterChannel () : Channel(), Alarm(MSG_CYCLE), counterSum(0), counter(0), msgcnt(0), boot(true) {}
   virtual ~MeterChannel () {}
 
   uint8_t status () const {
@@ -270,39 +271,71 @@ public:
   }
 
   void next () {
-    MeterList1 l1 = getList1();
-    uint16_t dx = 1;
-    switch( l1.meterType() ) {
-    case 1: dx = l1.constantGas(); break;
-    case 2: dx = l1.constantIR(); break;
-    case 4: dx = l1.constantLed(); break;
-    default: break;
-    }
-    counter += dx;
-    power += dx;
+    // only count rotations/flashes and calculate real value when sending, to prevent inaccuracy
+    counter++;
+
     sled.ledOn(millis2ticks(300));
-    DHEXLN(counter);
+    
+    #ifndef NDEBUG
+      DHEXLN(counter);
+    #endif
   }
 
   virtual void trigger (AlarmClock& clock) {
     tick = MSG_CYCLE;
     clock.add(*this);
-    //DHEXLN(counter);
-    power *= (seconds2ticks(60UL*60) / MSG_CYCLE);
-    switch( getList1().meterType() ) {
-    case 1:
-      ((GasPowerEventCycleMsg&)msg).init(msgcnt++,boot,counter,power);
+
+    MeterList1 l1 = getList1();
+    uint8_t metertype = l1.meterType(); // cache metertype to reduce eeprom access
+
+    // copy value, to be consistent during calculation (counter may change when an interrupt is triggered)
+    uint32_t c = counter;
+    counter = 0;
+    
+    uint16_t sigs = 1;
+    switch( metertype ) {
+      case 1: sigs = l1.constantGas(); break;
+      case 2: sigs = l1.constantIR(); break;
+      case 4: sigs = l1.constantLed(); break;
+      default: break;
+    }
+
+    // calculate consumption per signal
+    uint32_t consumptionPerSignal = 1000000 / sigs;
+
+    counterSum = counterSum + c;
+
+    // calculate sum 
+    uint32_t consumptionSum = (counterSum * consumptionPerSignal) / 100;
+
+    // TODO verify handling the overflow
+    if(consumptionSum > maxVal){
+
+      uint64_t maxCounterSum = (maxVal * 100) /  countPerSignal;
+      // security check if counterSum is really higher than maxCounterSum to prevent negative overflow
+      if(counterSum > maxCounterSum)
+        counterSum = counterSum - maxCounterSum;
+        
+      consumptionSum = consumptionSum - maxVal;
+    }
+
+    // calculate consumption whithin the last MSG_CYCLE period
+    uint32_t actualConsumption = ((c * consumptionPerSignal) / 100) * (seconds2ticks(3600) / MSG_CYCLE);
+    
+    switch( metertype ) {
+    case 1: 
+      ((GasPowerEventCycleMsg&)msg).init(msgcnt++,boot,consumptionSum,actualConsumption);
       break;
-    case 2:
-    case 4:
-      ((PowerEventCycleMsg&)msg).init(msgcnt++,boot,counter,power);
+    case 2: 
+    case 4: 
+      ((PowerEventCycleMsg&)msg).init(msgcnt++,boot,consumptionSum,actualConsumption);
       break;
     default:
       break;
     }
+
     device().sendPeerEvent(msg,*this);
     boot = false;
-    power = 0;
   }
 };
 

--- a/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
+++ b/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
@@ -285,12 +285,17 @@ public:
     tick = MSG_CYCLE;
     clock.add(*this);
 
+    uint32_t consumptionPerSignal;
+    uint32_t consumptionSum;
+    uint32_t actualConsumption;
+
     MeterList1 l1 = getList1();
     uint8_t metertype = l1.meterType(); // cache metertype to reduce eeprom access
 
     // copy value, to be consistent during calculation (counter may change when an interrupt is triggered)
     uint32_t c = counter;
     counter = 0;
+    counterSum = counterSum + c;
     
     uint16_t sigs = 1;
     switch( metertype ) {
@@ -300,34 +305,37 @@ public:
       default: break;
     }
 
-    // calculate consumption per signal
-    uint32_t consumptionPerSignal = 1000000 / sigs;
-
-    counterSum = counterSum + c;
-    
-    // calculate sum 
-    uint32_t consumptionSum = (counterSum * consumptionPerSignal) / 100 + 1;
-
-    // TODO verify handling the overflow
-    if(consumptionSum > maxVal + 1){
-
-      uint64_t maxCounterSum = (maxVal * 100) /  consumptionPerSignal;
-      // security check if counterSum is really higher than maxCounterSum to prevent negative overflow
-      if(counterSum > maxCounterSum)
-        counterSum = counterSum - maxCounterSum;
-        
-      consumptionSum = consumptionSum - maxVal;
-    }
-
-    // calculate consumption whithin the last MSG_CYCLE period
-    uint32_t actualConsumption = ((c * consumptionPerSignal) / 100 + 1) * (seconds2ticks(3600) / MSG_CYCLE);
-    
     switch( metertype ) {
-    case 1: 
+    case 1:
+      consumptionSum = counterSum * sigs;
+      actualConsumption = (c * sigs * 10) / (MSG_CYCLE*2 / 60);
+
+      // TODO handle overflow
+      
       ((GasPowerEventCycleMsg&)msg).init(msgcnt++,boot,consumptionSum,actualConsumption);
       break;
     case 2: 
     case 4: 
+      // calculate consumption per signal
+      consumptionPerSignal = 1000000 / sigs;
+      
+      // calculate sum 
+      consumptionSum = (counterSum * consumptionPerSignal) / 100 + 1;
+  
+      // TODO verify handling the overflow
+      if(consumptionSum > maxVal + 1){
+  
+        uint64_t maxCounterSum = (maxVal * 100) /  consumptionPerSignal;
+        // security check if counterSum is really higher than maxCounterSum to prevent negative overflow
+        if(counterSum > maxCounterSum)
+          counterSum = counterSum - maxCounterSum;
+          
+        consumptionSum = consumptionSum - maxVal;
+      }
+  
+      // calculate consumption whithin the last MSG_CYCLE period
+      actualConsumption = ((c * consumptionPerSignal) / 100 + 1) * (seconds2ticks(3600) / MSG_CYCLE);
+      
       ((PowerEventCycleMsg&)msg).init(msgcnt++,boot,consumptionSum,actualConsumption);
       break;
     default:

--- a/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
+++ b/examples/HM-ES-TX-WM/HM-ES-TX-WM.ino
@@ -304,14 +304,14 @@ public:
     uint32_t consumptionPerSignal = 1000000 / sigs;
 
     counterSum = counterSum + c;
-
+    
     // calculate sum 
-    uint32_t consumptionSum = (counterSum * consumptionPerSignal) / 100;
+    uint32_t consumptionSum = (counterSum * consumptionPerSignal) / 100 + 1;
 
     // TODO verify handling the overflow
-    if(consumptionSum > maxVal){
+    if(consumptionSum > maxVal + 1){
 
-      uint64_t maxCounterSum = (maxVal * 100) /  countPerSignal;
+      uint64_t maxCounterSum = (maxVal * 100) /  consumptionPerSignal;
       // security check if counterSum is really higher than maxCounterSum to prevent negative overflow
       if(counterSum > maxCounterSum)
         counterSum = counterSum - maxCounterSum;
@@ -320,7 +320,7 @@ public:
     }
 
     // calculate consumption whithin the last MSG_CYCLE period
-    uint32_t actualConsumption = ((c * consumptionPerSignal) / 100) * (seconds2ticks(3600) / MSG_CYCLE);
+    uint32_t actualConsumption = ((c * consumptionPerSignal) / 100 + 1) * (seconds2ticks(3600) / MSG_CYCLE);
     
     switch( metertype ) {
     case 1: 


### PR DESCRIPTION
The old calculation worked only for gas when 1m³ are 100 rotations or for power when 1kWh are 100 rotations because only the ticks per unit is added per tick.

The new calculation should work for gas/ir/led counter.
I used only one counter to count the rotations because when you use a variable and add the calculated value you loose precision.