### PR TITLE
fixed wrong motion detection while sending

### DIFF
--- a/Motion.h
+++ b/Motion.h
@@ -184,7 +184,10 @@ public:
       }
       MotionEventMsg& msg = (MotionEventMsg&)ChannelType::device().message();
       msg.init(ChannelType::device().nextcount(),ChannelType::number(),++counter,status(),ChannelType::getList1().minInterval());
+	  
+	  pirInterruptOff();
       ChannelType::device().sendPeerEvent(msg,*this);
+	  pirInterruptOn();
     }
     else if ( ChannelType::getList1().captureWithinInterval() == true ) {
       // we have had a motion during quiet interval


### PR DESCRIPTION
When using the default interval (240 seconds) and enabled
captureWithinInterval the state never changed back to "no motion"
because when sending the motion from the captureWithinInterval it
triggered a second motion which than caused captureWithinInterval to
retrigger and so on