### PR TITLE
reduce sending of state when not nessesary

### DIFF
--- a/Motion.h
+++ b/Motion.h
@@ -174,7 +174,9 @@ public:
   virtual void trigger (__attribute__ ((unused)) AlarmClock& clock) {
     if( quiet.enabled == false ) {
 	  // reset state timer because motion will be send now
+	  sysclock.cancel(cycle);
 	  cycle.set(LIGHTCYCLE);
+	  sysclock.add(cycle);
 	  
       DPRINTLN(F("Motion"));
       // start timer to end quiet interval
@@ -191,7 +193,9 @@ public:
     }
     else if ( ChannelType::getList1().captureWithinInterval() == true ) {
 	  // reset state timer because motion will be send when interval is over
+	  sysclock.cancel(cycle);
 	  cycle.set(LIGHTCYCLE);
+	  sysclock.add(cycle);
 		
       // we have had a motion during quiet interval
       quiet.motion = true;

--- a/Motion.h
+++ b/Motion.h
@@ -107,8 +107,8 @@ class MotionChannel : public Channel<HalType,MotionList1,EmptyList,List4,PeerCou
     }
   };
 
-  // send the brightness every 4 minutes to the master
-  #define LIGHTCYCLE seconds2ticks(4*60)
+  // send the brightness every 5 minutes to the master
+  #define LIGHTCYCLE seconds2ticks(5*60)
   class Cycle : public Alarm {
   public:
     MotionChannel& channel;
@@ -173,6 +173,9 @@ public:
   // this runs synch to application
   virtual void trigger (__attribute__ ((unused)) AlarmClock& clock) {
     if( quiet.enabled == false ) {
+	  // reset state timer because motion will be send now
+	  cycle.set(LIGHTCYCLE);
+	  
       DPRINTLN(F("Motion"));
       // start timer to end quiet interval
       quiet.tick = getMinInterval();
@@ -187,6 +190,9 @@ public:
       ChannelType::device().sendPeerEvent(msg,*this);
     }
     else if ( ChannelType::getList1().captureWithinInterval() == true ) {
+	  // reset state timer because motion will be send when interval is over
+	  cycle.set(LIGHTCYCLE);
+		
       // we have had a motion during quiet interval
       quiet.motion = true;
     }

--- a/Motion.h
+++ b/Motion.h
@@ -191,12 +191,7 @@ public:
       msg.init(ChannelType::device().nextcount(),ChannelType::number(),++counter,status(),ChannelType::getList1().minInterval());
       ChannelType::device().sendPeerEvent(msg,*this);
     }
-    else if ( ChannelType::getList1().captureWithinInterval() == true ) {
-	  // reset state timer because motion will be send when interval is over
-	  sysclock.cancel(cycle);
-	  cycle.set(LIGHTCYCLE);
-	  sysclock.add(cycle);
-		
+    else if ( ChannelType::getList1().captureWithinInterval() == true ) {	
       // we have had a motion during quiet interval
       quiet.motion = true;
     }


### PR DESCRIPTION
The state message only needs to be send when there is no motion send
during the interval.
The state interval can be reset when a motion message was send.

Additionaly 5 minutes for the interval seems more than the original
homematic PIR (compared to a HM-Sen-MDIR-O-2)