### PR TITLE
Added seperate PositionSensor class for ThreeStateChannel position ha…

### DIFF
--- a/Sensors.h
+++ b/Sensors.h
@@ -8,6 +8,8 @@
 
 namespace as {
 
+enum Positions { NoPos=0, PosA, PosB, PosC };
+
 class Sensor {
 protected:
   bool _present;
@@ -15,7 +17,7 @@ public:
   Sensor () : _present(false) {}
   void init () {}
   bool present () { return _present; }
-  void measure (__attribute__((unused)) bool async=false) {}
+  void measure (__attribute__((unused)) bool async) {}
 };
 
 class Brightness : public virtual Sensor {
@@ -54,6 +56,15 @@ public:
   uint16_t pressure () { return _pressure; }
 };
 
+class PositionSensor : public virtual Sensor {
+protected:
+  uint8_t  _position;
+  uint16_t _updatecycle;
+public:
+  PositionSensor () : _position(0), _updatecycle(1) {}
+  uint8_t position () { return _position; }
+  uint16_t updatecycle () { return _updatecycle; }
+};
 
 } // end namespace
 


### PR DESCRIPTION
Hallo papa,

[quote]
Im Prinzip schon. Ich würde das ganze gern über ein weiteres Template-Argument machen. So wie zum Beispiel der MotionChannel den LightSensor einbindet. Sonst geht es nur über eine virtuelle Moethde. Die kostet aber Speicher und außerdem brauchen die 2 Pinvariablen dann auch nicht mehr in der Klasse sein.
[/quote]

Ok, gute Idee. Ich habe mir MotionChannel / LightSensor angeschaut und auf dieser Basis versucht einen "PositionSensor" zu bauen, zur Verwendung in ThreeStateChannel.
Zweck:
1. eigene/custom Generierung von Positions (z.B. ADC) ohne ThreeStateChannel.h ändern zu müssen
2. Update/Messintervall ebenso änderbar ohne ThreeStateChannel.h anzufassen

Schau Dir bitte mal den pull request an ob es so passt oder ich noch was ändern soll.

Danke & Grüße,
Tom
