### PR TITLE
Fixed longpress for blind actor

### DIFF
--- a/Blind.h
+++ b/Blind.h
@@ -181,26 +181,17 @@ class BlindStateMachine : public StateMachine<BlindPeerList> {
       set(millis2ticks(100));
       clock.add(*this);
     }
-    
-    void cancel (){
-      clock.cancel(*this);
-    }
-    
     void stop (AlarmClock& clock) {
-      if(sysclock.get(*this) > 0) {
-        if( done > fulltime ) done = fulltime;
-        uint8_t dx = (done * 200UL) / fulltime;
-        if( sm.state == AS_CM_JT_RAMPON ) {
-          if( dx > (200-startlevel) ) dx = 200-startlevel;
-          sm.updateLevel(startlevel + dx);
-        }
-        else if( sm.state == AS_CM_JT_RAMPOFF ) {
-          if( dx > startlevel ) dx = startlevel;
-          sm.updateLevel(startlevel - dx);
-        }
+      clock.cancel(*this);
+      if( done > fulltime ) done = fulltime;
+      uint8_t dx = (done * 200UL) / fulltime;
+      if( sm.state == AS_CM_JT_RAMPON ) {
+        if( dx > (200-startlevel) ) dx = 200-startlevel;
+        sm.updateLevel(startlevel + dx);
       }
-      else {
-        clock.cancel(*this);
+      else if( sm.state == AS_CM_JT_RAMPOFF ) {
+        if( dx > startlevel ) dx = startlevel;
+        sm.updateLevel(startlevel - dx);
       }
     }
     virtual void trigger (AlarmClock& clock) {

--- a/Blind.h
+++ b/Blind.h
@@ -181,17 +181,26 @@ class BlindStateMachine : public StateMachine<BlindPeerList> {
       set(millis2ticks(100));
       clock.add(*this);
     }
-    void stop (AlarmClock& clock) {
+    
+    void cancel (){
       clock.cancel(*this);
-      if( done > fulltime ) done = fulltime;
-      uint8_t dx = (done * 200UL) / fulltime;
-      if( sm.state == AS_CM_JT_RAMPON ) {
-        if( dx > (200-startlevel) ) dx = 200-startlevel;
-        sm.updateLevel(startlevel + dx);
+    }
+    
+    void stop (AlarmClock& clock) {
+      if(sysclock.get(*this) > 0) {
+        if( done > fulltime ) done = fulltime;
+        uint8_t dx = (done * 200UL) / fulltime;
+        if( sm.state == AS_CM_JT_RAMPON ) {
+          if( dx > (200-startlevel) ) dx = 200-startlevel;
+          sm.updateLevel(startlevel + dx);
+        }
+        else if( sm.state == AS_CM_JT_RAMPOFF ) {
+          if( dx > startlevel ) dx = startlevel;
+          sm.updateLevel(startlevel - dx);
+        }
       }
-      else if( sm.state == AS_CM_JT_RAMPOFF ) {
-        if( dx > startlevel ) dx = startlevel;
-        sm.updateLevel(startlevel - dx);
+      else {
+        clock.cancel(*this);
       }
     }
     virtual void trigger (AlarmClock& clock) {

--- a/Blind.h
+++ b/Blind.h
@@ -232,6 +232,7 @@ protected:
     if( trigstate == AS_CM_JT_RAMPON || trigstate == AS_CM_JT_RAMPOFF ) {
       if( trigdest != 0xff ) {
         // update level to destlevel
+        update.cancel();
         updateLevel(trigdest);
       }
     }


### PR DESCRIPTION
Wenn man einen langen Tastendruck macht und maxTimeFirstDir auf 0.5 Sekunden steht (Standard wenn Einstellung über CCU vorgenommen), dann muss jede Nachricht verarbeitet werden, da diese alle 250ms gesendet werden.
Wird eine Nachricht verpast werden die 0.5 Sekunden erreicht und der Aktor stoppt.
Nach der nächsten Nachricht setzt er die Bewegung fort.

Daher ist es wichtig, dass der Aktor möglichst wenig Arbeit während eines LongPress hat.

Die Berechnung des Levels muss nicht während der Bewegung stattfinden. Es reicht aus, wenn dies am Ende passiert.

Bei der alten Implementierung gab es auch das Problem, dass wenn statusInfoMinDly  auf 1 Sekunde oder weniger gesetzt war, immer zwischendurch eine Statusnachricht geschickt wurde, da das Levelupdate nur jede Sekunde passierte und dann schon der Alarm für die Statusnachricht ausgelöst wurde.

Vorteil bei dieser Implementierung ist auch, dass das nacher das neue Level mit einer Ausflösung von 100ms anstatt 1 Sekunde berechnet wird. Dies kommt bei Longpress fahrten oder bei manuellem Stoppen der Fahrt vor.