### PR TITLE
Added parameter for drivetime

### DIFF
--- a/Blind.h
+++ b/Blind.h
@@ -224,7 +224,7 @@ public:
   BlindStateMachine () : StateMachine<BlindPeerList>(), level(0), destlevel(0), /*alarm(*this),*/ update(*this), list1(0) {}
   virtual ~BlindStateMachine () {}
 
-  virtual void switchState(uint8_t oldstate,uint8_t newstate) {
+  virtual void switchState(uint8_t oldstate,uint8_t newstate, uint32_t statedelay) {
     DPRINT("Switch from ");DHEX(oldstate);DPRINT(" to ");DHEXLN(newstate);
     switch( newstate ) {
     case AS_CM_JT_RAMPON:

--- a/StateMachine.h
+++ b/StateMachine.h
@@ -51,7 +51,7 @@ protected:
       sysclock.cancel(*this);
       // if state is different
       while (state != next) {
-        switchState(state, next);
+        switchState(state, next, delay);
         state = next;
 
         if (delay == DELAY_NO) {
@@ -68,7 +68,7 @@ protected:
     }
   }
 
-  virtual void switchState(__attribute__((unused)) uint8_t oldstate,__attribute__((unused)) uint8_t newstate) {}
+  virtual void switchState(__attribute__((unused)) uint8_t oldstate,__attribute__((unused)) uint8_t newstat, __attribute__((unused)) uint32_t) {}
 
   void jumpToTarget(const PeerList& lst) {
     uint8_t next = getJumpTarget(state,lst);

--- a/StateMachine.h
+++ b/StateMachine.h
@@ -68,7 +68,7 @@ protected:
     }
   }
 
-  virtual void switchState(__attribute__((unused)) uint8_t oldstate,__attribute__((unused)) uint8_t newstat, __attribute__((unused)) uint32_t) {}
+  virtual void switchState(__attribute__((unused)) uint8_t oldstate,__attribute__((unused)) uint8_t newstate, __attribute__((unused)) uint32_t) {}
 
   void jumpToTarget(const PeerList& lst) {
     uint8_t next = getJumpTarget(state,lst);

--- a/examples/HM-LC-Bl1-FM/HM-LC-Bl1-FM.ino
+++ b/examples/HM-LC-Bl1-FM/HM-LC-Bl1-FM.ino
@@ -70,12 +70,12 @@ public:
   BlChannel () {}
   virtual ~BlChannel () {}
 
-  virtual void switchState(uint8_t oldstate,uint8_t newstate) {
+  virtual void switchState(uint8_t oldstate,uint8_t newstate, uint32_t stateDelay) {
     BaseChannel::switchState(oldstate, newstate);
-    if( newstate == AS_CM_JT_RAMPON ) {
+    if( newstate == AS_CM_JT_RAMPON && stateDelay > 0 ) {
       motorUp();
     }
-    else if( newstate == AS_CM_JT_RAMPOFF ) {
+    else if( newstate == AS_CM_JT_RAMPOFF && stateDelay > 0 ) {
       motorDown();
     }
     else {

--- a/examples/HM-LC-Bl1-FM/HM-LC-Bl1-FM.ino
+++ b/examples/HM-LC-Bl1-FM/HM-LC-Bl1-FM.ino
@@ -71,7 +71,7 @@ public:
   virtual ~BlChannel () {}
 
   virtual void switchState(uint8_t oldstate,uint8_t newstate, uint32_t stateDelay) {
-    BaseChannel::switchState(oldstate, newstate);
+    BaseChannel::switchState(oldstate, newstate, stateDelay);
     if( newstate == AS_CM_JT_RAMPON && stateDelay > 0 ) {
       motorUp();
     }


### PR DESCRIPTION
Folgende Situation:
Man hat den Rolladen auf eine bestimmte Position fahren lassen.
Nun drückt man den Knopf für die selbe Position erneut.
Jetzt kann es sein, dass der Aktor für wenige Millisekunden das Rollo fahren lässt.

Das Problem ist, dass auch wenn eine Fahrzeit von 0 Sekunden berechnet wird, weil der Rolladen schon auf dieser Position ist, werden die Funktionen motorUp oder motorDown ausgelöst.

Indem man die beabsichtigte Verzögerung mit an die Funktion switchState übergibt, kann man im Sketch entscheiden was man machen möchte und bekommt trotzdem alle Stateswitches mit.