### PR TITLE
Atmega32 support

### DIFF
--- a/Activity.h
+++ b/Activity.h
@@ -10,13 +10,14 @@
 #include <AlarmClock.h>
 #include <Radio.h>
 
-#ifdef ARDUINO_ARCH_AVR
+#ifndef ARDUINO_AVR_ATmega32 && ifdef ARDUINO_ARCH_AVR
 #include <LowPower.h>
 #endif
 
 namespace as {
 
-#ifdef ARDUINO_ARCH_AVR
+#ifndef ARDUINO_AVR_ATmega32 && ifdef ARDUINO_ARCH_AVR
+
 
 template <bool ENABLETIMER2=false, bool ENABLEADC=false>
 class Idle {
@@ -190,7 +191,7 @@ public:
   void sleepForever (Hal& hal) {
     hal.radio.setIdle();
     while( true ) {
-#ifdef ARDUINO_ARCH_AVR
+#ifndef ARDUINO_AVR_ATmega32 && ifdef ARDUINO_ARCH_AVR
       LowPower.powerDown(SLEEP_FOREVER,ADC_OFF,BOD_OFF);
 #endif
     }

--- a/AlarmClock.cpp
+++ b/AlarmClock.cpp
@@ -21,7 +21,7 @@ void rtccallback () {
     --rtc;
 }
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
 ISR(TIMER1_OVF_vect) {
   callback();
 }

--- a/AlarmClock.h
+++ b/AlarmClock.h
@@ -98,7 +98,7 @@ extern void rtccallback(void);
 class SysClock : public AlarmClock {
 public:
   void init() {
-  #if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+  #if ARDUINO_ARCH_AVR
   #define TIMER1_RESOLUTION 65536UL  // Timer1 is 16 bit
     // use Time1 on AVR
     TCCR1B = _BV(WGM13);        // set mode as phase and frequency correct pwm, stop the timer
@@ -145,7 +145,7 @@ public:
   }
 
   void disable () {
-  #ifdef ARDUINO_ARCH_ATMEGA32
+  #ifdef ARDUINO_AVR_ATmega32
     TIMSK &= ~_BV(TOIE1);
   #elif defined(ARDUINO_ARCH_AVR)
     TIMSK1 &= ~_BV(TOIE1);
@@ -155,7 +155,7 @@ public:
   }
 
   void enable () {
-  #ifdef ARDUINO_ARCH_ATMEGA32
+  #ifdef ARDUINO_AVR_ATmega32
     TIMSK |= _BV(TOIE1);
   #elif defined(ARDUINO_ARCH_AVR)
     TIMSK1 |= _BV(TOIE1);
@@ -180,7 +180,7 @@ public:
   RTC () : ovrfl(0) {}
 
   void init () {
-#ifdef ARDUINO_ARCH_ATMEGA32
+#ifdef ARDUINO_AVR_ATmega32
     TIMSK &= ~(1<<TOIE2); //Disable timer2 interrupts
     ASSR  |= (1<<AS2); //Enable asynchronous mode
     TCNT2 = 0; //set initial counter value
@@ -209,7 +209,7 @@ public:
     if( resetovrflow == true ) {
       ovrfl = 0;
     }
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
     return (256 * ovrfl) + TCNT2;
 #elif defined(ARDUINO_ARCH_STM32F1) && defined(_RTCLOCK_H_)
     return rtc_get_count();

--- a/AskSinPP.h
+++ b/AskSinPP.h
@@ -24,10 +24,6 @@
 #else
   typedef uint8_t uint8;
   typedef uint16_t uint16;
-  #ifdef ARDUINO_AVR_ATmega32
-  // does not compile for ATmega32
-  //  inline int8_t digitalPinToInterrupt(uint8_t pin) { return pin == 11 ? 1 : ( pin == 10 ? 0 : NOT_AN_INTERRUPT); } // D2 -> 0 && D3 -> 1
-  #endif
   // if we have no EnableInterrupt Library - and also no PCINT - use polling
   #ifndef EnableInterrupt_h
     #define enableInterrupt(pin,handler,mode) pinpolling##pin().enable(pin,handler,mode)

--- a/AskSinPP.h
+++ b/AskSinPP.h
@@ -24,8 +24,9 @@
 #else
   typedef uint8_t uint8;
   typedef uint16_t uint16;
-  #ifdef ARDUINO_ARCH_ATMEGA32
-    inline int8_t digitalPinToInterrupt(uint8_t pin) { return pin == 11 ? 1 : ( pin == 10 ? 0 : NOT_AN_INTERRUPT); } // D2 -> 0 && D3 -> 1
+  #ifdef ARDUINO_AVR_ATmega32
+  // does not compile for ATmega32
+  //  inline int8_t digitalPinToInterrupt(uint8_t pin) { return pin == 11 ? 1 : ( pin == 10 ? 0 : NOT_AN_INTERRUPT); } // D2 -> 0 && D3 -> 1
   #endif
   // if we have no EnableInterrupt Library - and also no PCINT - use polling
   #ifndef EnableInterrupt_h

--- a/Atomic.h
+++ b/Atomic.h
@@ -5,7 +5,7 @@
 #ifdef ARDUINO
   #include <Arduino.h>
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
   #include <util/atomic.h>
 #else
 

--- a/Button.h
+++ b/Button.h
@@ -8,7 +8,7 @@
 #include "AlarmClock.h"
 #include "Debug.h"
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
   typedef uint8_t WiringPinMode;
 #endif
 

--- a/MultiChannelDevice.h
+++ b/MultiChannelDevice.h
@@ -12,7 +12,7 @@
 #include <Led.h>
 #include <Activity.h>
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
 #include <avr/wdt.h>
 #endif
 
@@ -147,7 +147,7 @@ public:
 
   void bootloader () {
     DPRINTLN(F("BOOTLOADER"));
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
     wdt_enable(WDTO_250MS);
     while(1);
 #endif

--- a/Radio.h
+++ b/Radio.h
@@ -152,7 +152,7 @@ namespace as {
 
 
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
 
 template <uint8_t CS,uint8_t MOSI,uint8_t MISO,uint8_t SCLK, class PINTYPE=ArduinoPins>
 class AvrSPI {

--- a/actors/PWM.h
+++ b/actors/PWM.h
@@ -10,7 +10,7 @@
 
 namespace as {
 
-#if ARDUINO_ARCH_AVR or ARDUINO_ARCH_ATMEGA32
+#if ARDUINO_ARCH_AVR
 // we use this table for the dimmer levels
 static const uint8_t pwmtable[32] PROGMEM = {
     1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 10, 11, 13, 16, 19, 23,

--- a/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
+++ b/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
@@ -39,7 +39,7 @@ using namespace as;
 const struct DeviceInfo PROGMEM devinfo = {
     {0x83,0x2A,0xE1},       // Device ID
     "HMSwC00001",           // Device Serial
-    {0xF5,0x01},            // Device Model
+    {0xf2,0x01},            // Device Model
     0x01,                   // Firmware Version
     as::DeviceType::Switch, // Device Type
     {0x01,0x00}             // Info Bytes
@@ -51,16 +51,6 @@ typedef StatusLed<12> LedType; // PD4
 typedef AskSin<LedType,NoBattery,Radio<RadioSPI,11> > Hal; // PD3
 Hal hal;
 
-DEFREGISTER(Reg0, MASTERID_REGS, DREG_INTKEY)
-class SwList0 : public RegList0<Reg0> {
-  public:
-    SwList0(uint16_t addr) : RegList0<Reg0>(addr) {}
-    void defaults() {
-      clear();
-      intKeyVisible(true);
-    }
-};
-
 uint8_t SwitchPin (uint8_t number) {
   switch( number ) {
     case 4: return RELAY2_PIN;
@@ -68,31 +58,31 @@ uint8_t SwitchPin (uint8_t number) {
   return RELAY1_PIN;
 }
 
-typedef SwitchChannel<Hal, PEERS_PER_SWCHANNEL, SwList0>  SwChannel;
-typedef RemoteChannel<Hal, PEERS_PER_BTNCHANNEL, SwList0> BtnChannel;
+typedef SwitchChannel<Hal,PEERS_PER_SWCHANNEL,List0>  SwChannel;
+typedef RemoteChannel<Hal,PEERS_PER_BTNCHANNEL,List0> BtnChannel;
 
-class MixDevice : public ChannelDevice<Hal, VirtBaseChannel<Hal, SwList0>, 4, SwList0> {
+class MixDevice : public ChannelDevice<Hal,VirtBaseChannel<Hal,List0>,4> {
 public:
-  VirtChannel<Hal, SwChannel, SwList0>  swc1, swc2;
-  VirtChannel<Hal, BtnChannel, SwList0> btc1, btc2;
+  VirtChannel<Hal,BtnChannel,List0> c1,c2;
+  VirtChannel<Hal,SwChannel,List0>  c3,c4;
 public:
-  typedef VirtBaseChannel<Hal, SwList0> ChannelType;
-  typedef ChannelDevice<Hal, ChannelType, 4, SwList0> DeviceType;
-  MixDevice (const DeviceInfo& info,uint16_t addr) : DeviceType(info, addr) {
-    DeviceType::registerChannel(swc1, 1);
-    DeviceType::registerChannel(swc2, 2);
-    DeviceType::registerChannel(btc1, 3);
-    DeviceType::registerChannel(btc2, 4);
+  typedef VirtBaseChannel<Hal,List0> ChannelType;
+  typedef ChannelDevice<Hal,ChannelType,4> DeviceType;
+  MixDevice (const DeviceInfo& info,uint16_t addr) : DeviceType(info,addr) {
+    DeviceType::registerChannel(c1,1);
+    DeviceType::registerChannel(c2,2);
+    DeviceType::registerChannel(c3,3);
+    DeviceType::registerChannel(c4,4);
   }
   virtual ~MixDevice () {}
 
-  BtnChannel& btn1Channel () { return btc1; }
-  BtnChannel& btn2Channel () { return btc2; }
-  SwChannel&  sw1Channel  () { return swc1; }
-  SwChannel&  sw2Channel  () { return swc2; }
+  BtnChannel& btn1Channel () { return c1; }
+  BtnChannel& btn2Channel () { return c2; }
+  SwChannel&  sw1Channel  () { return c3; }
+  SwChannel&  sw2Channel  () { return c4; }
 
   bool pollRadio () {
-    bool worked = Device<Hal,SwList0>::pollRadio();
+    bool worked = Device<Hal,List0>::pollRadio();
     for( uint8_t i=1; i<=this->channels(); ++i ) {
       ChannelType& ch = channel(i);
       if( ch.changed() == true ) {
@@ -130,6 +120,11 @@ void setup () {
 }
 
 void loop() {
+//  bool pinchanged = sdev.btn1Channel().checkpin();
+//  pinchanged |= sdev.btn2Channel().checkpin();
   bool worked = hal.runready();
   bool poll = sdev.pollRadio();
+//  if( pinchanged == false && worked == false && poll == false ) {
+//    hal.activity.savePower<Idle<> >(hal);
+//  }
 }

--- a/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
+++ b/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
@@ -1,6 +1,7 @@
 //- -----------------------------------------------------------------------------------------------------------------------
 // AskSin++
 // 2016-10-31 papa Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+// 2018-10-01 stan23 Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //- -----------------------------------------------------------------------------------------------------------------------
 
 // define this to read the device id, serial and device type from bootloader section
@@ -18,13 +19,13 @@
 #include <Switch.h>
 #include <Remote.h>
 
-// see https://github.com/eaconner/ATmega32-Arduino for Arduino Pin Mapping
+// use MightyCore Standard pinout for ATmega32
 
 #define RELAY1_PIN 0 // PB0
 #define RELAY2_PIN 1 // PB1
 
-#define BUTTON1_PIN 31 // PA0
-#define BUTTON2_PIN 30 // PA1
+#define BUTTON1_PIN 24 // PA0
+#define BUTTON2_PIN 25 // PA1
 
 // number of available peers per channel
 // number of available peers per channel

--- a/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
+++ b/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
@@ -1,7 +1,6 @@
 //- -----------------------------------------------------------------------------------------------------------------------
 // AskSin++
 // 2016-10-31 papa Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
-// 2018-10-01 stan23 Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //- -----------------------------------------------------------------------------------------------------------------------
 
 // define this to read the device id, serial and device type from bootloader section
@@ -19,7 +18,7 @@
 #include <Switch.h>
 #include <Remote.h>
 
-// use MightyCore Standard pinout
+// see https://github.com/eaconner/ATmega32-Arduino for Arduino Pin Mapping
 
 #define RELAY1_PIN 0 // PB0
 #define RELAY2_PIN 1 // PB1
@@ -120,6 +119,11 @@ void setup () {
 }
 
 void loop() {
+//  bool pinchanged = sdev.btn1Channel().checkpin();
+//  pinchanged |= sdev.btn2Channel().checkpin();
   bool worked = hal.runready();
   bool poll = sdev.pollRadio();
+//  if( pinchanged == false && worked == false && poll == false ) {
+//    hal.activity.savePower<Idle<> >(hal);
+//  }
 }

--- a/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
+++ b/examples/custom/HM-LC-SW2-FM/HM_LC_SW2_FM.ino
@@ -1,6 +1,7 @@
 //- -----------------------------------------------------------------------------------------------------------------------
 // AskSin++
 // 2016-10-31 papa Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+// 2018-10-01 stan23 Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //- -----------------------------------------------------------------------------------------------------------------------
 
 // define this to read the device id, serial and device type from bootloader section
@@ -18,7 +19,7 @@
 #include <Switch.h>
 #include <Remote.h>
 
-// see https://github.com/eaconner/ATmega32-Arduino for Arduino Pin Mapping
+// use MightyCore Standard pinout
 
 #define RELAY1_PIN 0 // PB0
 #define RELAY2_PIN 1 // PB1
@@ -119,11 +120,6 @@ void setup () {
 }
 
 void loop() {
-//  bool pinchanged = sdev.btn1Channel().checkpin();
-//  pinchanged |= sdev.btn2Channel().checkpin();
   bool worked = hal.runready();
   bool poll = sdev.pollRadio();
-//  if( pinchanged == false && worked == false && poll == false ) {
-//    hal.activity.savePower<Idle<> >(hal);
-//  }
 }


### PR DESCRIPTION
Replace the deprecated ATmega32 support using the definition from [1], [2] by MightyCore [3].

[1] https://github.com/eaconner/ATmega32-Arduino
[2] http://openhardware.ro/using-atmega32-arduino-ide/
[3] https://github.com/MCUdude/MightyCore