### PR TITLE
Fix RTC sleep mode to get minimum power-save current

### DIFF
--- a/Activity.h
+++ b/Activity.h
@@ -109,7 +109,7 @@ public:
     else if( ticks > millis2ticks(15)  ) { sleeptime = SLEEP_15MS; }
 
     uint32_t c1 = rtc.getCounter(true);
-    LowPower.powerExtStandby(sleeptime,ADC_OFF,BOD_OFF,TIMER2_ON);
+    LowPower.powerSave(sleeptime,ADC_OFF,BOD_OFF,TIMER2_ON);
     uint32_t c2 = rtc.getCounter(false);
     offset = (c2 - c1) * seconds2ticks(1) / 256;
     // DHEX(ticks);DPRINT("  ");DHEX(c1);DPRINT(":");DHEX(c2);DPRINT("  ");DHEXLN(offset);


### PR DESCRIPTION
Der Fix verringert den Ruhestrom im RTC Mode auf ca. 1uA.
Wake-up funktioniert weiterhin.
Getestet durch user fhemfreund.