### PR TITLE
change filter settings, to enhance response time

### DIFF
--- a/sensors/Bme280.h
+++ b/sensors/Bme280.h
@@ -12,6 +12,16 @@
 
 namespace as {
 
+BME280I2C::Settings settings(
+   BME280::OSR_X1, // Temperature Oversampling Rate (tempOSR): OSR Enum, default = OSR_X1
+   BME280::OSR_X1, // Humidity Oversampling Rate (humOSR): OSR Enum, default = OSR_X1
+   BME280::OSR_X1, // Pressure Oversampling Rate (presOSR): OSR Enum, default = OSR_X1
+   BME280::Mode_Forced, // Mode (mode): Mode Enum, default = Mode_Forced
+   BME280::StandbyTime_1000ms, // Standby Time (standbyTime): StandbyTime Enum, default = StandbyTime_1000ms
+   BME280::Filter_Off, // Filter (filter): Filter Enum, default = Filter_16
+   BME280::SpiEnable_False // SPI Enable: SpiEnable Enum, default = false
+);
+
 // https://github.com/finitespace/BME280
 class Bme280 : public Temperature, public Pressure, public Humidity {
   BME280I2C _bme;
@@ -19,6 +29,7 @@ public:
   Bme280 () {}
   void init () {
     _present = _bme.begin();
+    _bme.setSettings(settings);
   }
   bool measure (__attribute__((unused)) bool async=false) {
     if( present() == true ) {


### PR DESCRIPTION
according to the BME280 datasheet the Suggested settings for weather monitoring are:

Sensor mode: forced mode
Oversampling settings: pressure ×1, temperature ×1, humidity ×1
IIR filter settings: filter off

the default setting up to now was a filter setting of 16, which means we need 22 samples  to reach ≥75 % of step temperatur change, with the "Filter off" setting we only need 1 Sample

example: i put my BME280 sensor (which reports every 3 minutes) from room temperatur (23°C) into the freezer (-20°C)
without this change it takes a BME280 sensor more than 2 hours to report the right temperature...  after my change it only takes a few minutes...

before:
![image](https://user-images.githubusercontent.com/5165445/61162152-8cf91900-a507-11e9-8974-36b556d5deda.png)

after:
![image](https://user-images.githubusercontent.com/5165445/61162213-e5c8b180-a507-11e9-94fa-f1df45d0b271.png)


comparison of the measured temperatur of the BME280 (blue line) with a si7021 (orange line) sensor... ... i changed the filtering of the bme280 at midnight :)
![image](https://user-images.githubusercontent.com/5165445/61168521-a4f48b00-a54f-11e9-967a-06886a8ffd02.png)
