### PR TITLE
FreqTest, add MHz display

### DIFF
--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -17,10 +17,6 @@
 // Arduino pin for the LED
 // D4 == PIN 4 on Pro Mini
 #define LED_PIN 4
-#define LED_PIN2 5
-// Arduino pin for the config button
-// B0 == PIN 8 on Pro Mini
-#define CONFIG_BUTTON_PIN 8
 
 // all library classes are placed in the namespace 'as'
 using namespace as;
@@ -40,7 +36,7 @@ const struct DeviceInfo PROGMEM devinfo = {
  */
 typedef AvrSPI<10,11,12,13> RadioSPI;
 typedef Radio<RadioSPI,2> RadioType;
-typedef StatusLed<4> LedType;
+typedef StatusLed<LED_PIN> LedType;
 typedef AskSin<LedType,NoBattery,RadioType> HalType;
 
 
@@ -120,7 +116,8 @@ public:
       }
       else {
         freq = start+((end - start)/2);
-        DPRINT("Calculated Freq: 0x21");DHEX((uint8_t)(freq>>8));DHEXLN((uint8_t)(freq&0xff));
+        DPRINT("Calculated Freq: 0x21");DHEX((uint8_t)(freq>>8));DHEX((uint8_t)(freq&0xff));
+        printFreq(0x210000 + freq);DPRINTLN("");
 
         // store frequency
         DPRINT("Store into config area: ");DHEX((uint8_t)(freq>>8));DHEXLN((uint8_t)(freq&0xff));
@@ -160,12 +157,21 @@ public:
     freq = current;
     rssi=0;
     received=0;
-    DPRINT("Freq 0x21");DHEX(freq);DPRINT(": ");
+    DPRINT("Freq 0x21");DHEX(freq);
+    printFreq(0x210000 + freq);
+    DPRINT(": ");
     this->radio().initReg(CC1101_FREQ2, 0x21);
     this->radio().initReg(CC1101_FREQ1, freq >> 8);
     this->radio().initReg(CC1101_FREQ0, freq & 0xff);
     set(SCANTIME);
     sysclock.add(*this);
+  }
+
+  void printFreq(uint32_t freq) {
+    char buffer[16];
+    float val = (float)freq * 26.0 / 65536.0;
+    dtostrf(val, 8, 3, buffer);
+    DPRINT(buffer);DPRINT(" MHz");
   }
 };
 


### PR DESCRIPTION
- zusätzliche Anzeige der Frequenz in MHz beim Freq.test eines CC1101 Moduls.
- weiterhin LED pin usage korrigiert und config button define entfernt
- Output sieht jetzt so aus:
`
AskSin++ V4.0.3 (Jul 15 2019 19:58:46)
CC init1
CC Version: 14
 ready
Start searching ...
Freq 0x21656A 868.300 MHz: 583E8D.  1/65
Search for upper bound
Freq 0x21657A 868.306 MHz: 583E8D.  1/65
Freq 0x21658A 868.313 MHz: 583E8D.  1/65
Freq 0x21659A 868.319 MHz: 583E8D.  1/66
Freq 0x2165AA 868.325 MHz: 583E8D.  1/66
Freq 0x2165BA 868.332 MHz:   0/0
Search for lower bound
Freq 0x21655A 868.294 MHz: 583E8D.  1/64
Freq 0x21654A 868.287 MHz: 583E8D.  1/65
Freq 0x21653A 868.281 MHz: 583E8D.  1/64
Freq 0x21652A 868.274 MHz: 583E8D.  1/65
Freq 0x21651A 868.268 MHz: 583E8D.  1/65
Freq 0x21650A 868.262 MHz: 583E8D.  1/64
Freq 0x2164FA 868.255 MHz: 583E8D.  1/65
Freq 0x2164EA 868.249 MHz: 583E8D.  1/65
Freq 0x2164DA 868.243 MHz: 583E8D.  1/65
Freq 0x2164CA 868.236 MHz:   0/0

Done: 0x2164DA - 0x2165AA
Calculated Freq: 0x216542 868.284 MHz
Store into config area: 6542
`