### PR TITLE
 add broadcastEvent method to broadcast to all devices (to = 000000)

### DIFF
--- a/Device.h
+++ b/Device.h
@@ -537,7 +537,6 @@ public:
 
   template <class ChannelType>
     void broadcastEvent (Message& msg,const ChannelType& ch) {
-      getDeviceID(msg.from());
       msg.clearAck();
       msg.burstRequired(false);
       msg.setBroadcast();

--- a/Device.h
+++ b/Device.h
@@ -535,6 +535,16 @@ public:
     hal->sendPeer();
   }
 
+  template <class ChannelType>
+    void broadcastEvent (Message& msg,const ChannelType& ch) {
+      getDeviceID(msg.from());
+      msg.clearAck();
+      msg.burstRequired(false);
+      msg.setBroadcast();
+      send(msg,HMID::broadcast);
+      hal->sendPeer();
+    }
+
   void writeList (const GenericList& list,const uint8_t* data,uint8_t length) {
     for( uint8_t i=0; i<length; i+=2, data+=2 ) {
       list.writeRegister(*data,*(data+1));


### PR DESCRIPTION
wie in der E-Mail vorgeschlagen - jedoch als extra Methode, dann lassen wir broadcastPeerEvent (dem Namen nach auch richtig), weil an den Peer gebroadcastet wird.