### PR TITLE
Print rssi in signed dBm, fix ACTIVE_PING define range

### DIFF
--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -74,7 +74,12 @@ public:
   virtual ~TestDevice () {}
 
   virtual void trigger (__attribute__ ((unused)) AlarmClock& clock) {
-    DPRINT("  ");DDEC(received);DPRINT("/");DDECLN(rssi);
+    DPRINT("  ");DDEC(received);
+    if (!received) {
+      DPRINTLN("");
+    } else {
+      DPRINT(" / -");DDEC(rssi);DPRINTLN("dBm");
+    }
 
     if( mode == Search ) {
       if( received > 0 ) {
@@ -194,13 +199,13 @@ public:
   virtual ~InfoSender () {}
 
   virtual void trigger (AlarmClock& clock) {
+#ifdef ACTIVE_PING
     InfoActuatorStatusMsg msg;
     msg.init(cnt++, ch, hal.radio.rssi());
     msg.to(PING_TO);
     msg.from(PING_FROM);
     msg.ackRequired();
     msg.setRpten();
-#ifdef ACTIVE_PING
     sdev.radio().write(msg,msg.burstRequired());
 #endif
     sdev.led().ledOn(millis2ticks(100), 0);


### PR DESCRIPTION
- Ausgabe RSSI in dBm um besser zu sehen welche Module (im direkten Vergleich) einen besseren Wert haben
siehe
https://forum.fhem.de/index.php/topic,91740.msg984230.html#msg984230

- Fix des ACTIVE_PING define ranges
siehe
https://homematic-forum.de/forum/viewtopic.php?f=76&t=53845#p535927

Ausgabe sieht jetzt so aus:
```
AskSin++ V4.1.1 (Oct 18 2019 23:33:47)
CC init1
CC Version: 14
 - ready
Start searching ...
Freq 0x21656A 868.300 MHz: 583E8D.  1 / -68dBm
Search for upper bound
Freq 0x21657A 868.306 MHz:   0
Search for lower bound
Freq 0x21655A 868.294 MHz: 583E8D.  1 / -69dBm
Freq 0x21654A 868.287 MHz: 583E8D.  1 / -69dBm
Freq 0x21653A 868.281 MHz: 583E8D.  1 / -69dBm
Freq 0x21652A 868.274 MHz: 583E8D.  1 / -68dBm
Freq 0x21651A 868.268 MHz: 583E8D.  1 / -69dBm
Freq 0x21650A 868.262 MHz: 583E8D.  1 / -69dBm
Freq 0x2164FA 868.255 MHz: 583E8D.  1 / -68dBm
Freq 0x2164EA 868.249 MHz: 583E8D.  1 / -69dBm
Freq 0x2164DA 868.243 MHz: 583E8D.  1 / -68dBm
Freq 0x2164CA 868.236 MHz: 583E8D.  1 / -68dBm
Freq 0x2164BA 868.230 MHz:   0

Done: 0x2164CA - 0x21656A
Calculated Freq: 0x21651A 868.268 MHz
Store into config area: 651A
```