### PR TITLE
add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /.ino.cpp
 /.settings/
 **/.pio
+**/.vscode
 .idea
 .DS_Store


### PR DESCRIPTION
Let's ignore the .vscode folder for PlatformIO on Visual Studio Code.

The VSC generated .gitignore has this content:
```
.pio
.vscode/.browse.c_cpp.db*
.vscode/c_cpp_properties.json
.vscode/launch.json
.vscode/ipch
```

But I think ignoring the whole directory is better.