### PR TITLE
Add a 5 sec delay before starting on STM32, and be more verbose when storing to EEPROM

### DIFF
--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -150,14 +150,18 @@ public:
         printFreq(0x210000 + freq);DPRINTLN("");
 
         // store frequency
-        DPRINT("Store into config area: ");DHEX((uint8_t)(freq>>8));DHEXLN((uint8_t)(freq&0xff));
+        DPRINT("Store into config area: ");DHEX((uint8_t)(freq>>8));DHEX((uint8_t)(freq&0xff));
         StorageConfig sc = getConfigArea();
 #if defined ARDUINO_ARCH_STM32F1
         Wire.begin();
+        DPRINT(".");
 #endif
         sc.clear();
+        DPRINT(".");
         sc.setByte(CONFIG_FREQ1, freq>>8);
+        DPRINT(".");
         sc.setByte(CONFIG_FREQ2, freq&0xff);
+        DPRINT(".");
         sc.validate();
 
         DPRINTLN("stored!");
@@ -251,6 +255,9 @@ public:
 } info;
 
 void setup () {
+#if defined ARDUINO_ARCH_STM32F1
+  delay(5000);
+#endif
   DINIT(57600,ASKSIN_PLUS_PLUS_IDENTIFIER);
   sdev.init(hal);
   // start sender


### PR DESCRIPTION
Example print:
Store into config area: 65C2....stored!

This way it is easy to see if it get's stuck on storing to EEPROM.