### PR TITLE
Add SHT21 sensor support

### DIFF
--- a/examples/HM-WDS40-TH-I/HM-WDS40-TH-I.ino
+++ b/examples/HM-WDS40-TH-I/HM-WDS40-TH-I.ino
@@ -22,6 +22,7 @@
 #define SENSOR_BME280
 //#define SENSOR_DHT22
 //#define SENSOR_SHT10
+//#define SENSOR_SHT21
 //#define SENSOR_SHT31
 //#define SENSOR_SI7021
 
@@ -73,6 +74,10 @@ typedef Dht<4,DHT22> SensorType; // <DataPin, Type>
 #ifdef SENSOR_SHT10
 #include <sensors/Sht10.h>
 typedef Sht10<A4, A5> SensorType; // <DataPin, ClockPin>
+#endif
+#ifdef SENSOR_SHT21
+#include <sensors/Sht21.h>
+typedef Sht21<> SensorType; // I2C
 #endif
 #ifdef SENSOR_SHT31
 #include <sensors/Sht31.h>

--- a/sensors/Sht21.h
+++ b/sensors/Sht21.h
@@ -1,0 +1,48 @@
+//- -----------------------------------------------------------------------------------------------------------------------
+// AskSin++
+// 2018-11-02 jp112sdl Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+// 2020-01-03 manawyrm
+//- -----------------------------------------------------------------------------------------------------------------------
+
+#ifndef __SENSORS_SHT21_h__
+#define __SENSORS_SHT21_h__
+
+#include <Sensors.h>
+#include <Wire.h>
+#include <SHT21.h>
+
+namespace as {
+
+//https://github.com/manawyrm/SHT21
+template <uint8_t ADDRESS=0x40>
+class Sht21 : public Temperature, public Humidity {
+  SHT21 _sht21;
+public:
+  Sht21 () {}
+
+  void init () {
+    _present = _sht21.begin(ADDRESS);
+    DPRINT(F("SHT21 "));
+    if (_present) {
+      DPRINTLN(F("OK"));
+    } else {
+      DPRINTLN(F("ERROR"));
+    }
+  }
+
+  bool measure (__attribute__((unused)) bool async=false) {
+    if( present() == true ) {
+        if (_sht21.startMeasurement()) 
+        {
+            _temperature = _sht21.readTemperature();
+            _humidity = _sht21.readHumidity();
+            return true;
+        }
+    }
+    return false;
+  }
+};
+
+}
+
+#endif


### PR DESCRIPTION
This PR adds support for SHT21 sensors. 
The library is (roughly) based on Adafruit's SHT31 lib, which is already used in AskSin++. 