### PR TITLE
Proposal: 12 bit PWM using PCA9685

### DIFF
--- a/actors/PCA9685.h
+++ b/actors/PCA9685.h
@@ -1,0 +1,96 @@
+//- -----------------------------------------------------------------------------------------------------------------------
+// AskSin++
+// 2020-04-12 stan23 Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
+//- -----------------------------------------------------------------------------------------------------------------------
+// datasheet:
+// https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf
+
+#ifndef ACTORS_PCA9685_H_
+#define ACTORS_PCA9685_H_
+
+#include <Wire.h>
+
+
+#define PCA9685_ADDRESS           0x40    /* default address if A5-A0 are open */
+
+/* PCA9685 Registers */
+#define PCA9685_REG_MODE1         0x00    /* Mode Register 1 */
+#define PCA9685_REG_MODE2         0x01    /* Mode Register 2 */
+#define PCA9685_REG_SUBADR1       0x02    /* I2C-bus subaddress 1 */
+#define PCA9685_REG_SUBADR2       0x03    /* I2C-bus subaddress 2 */
+#define PCA9685_REG_SUBADR3       0x04    /* I2C-bus subaddress 3 */
+#define PCA9685_REG_ALLCALLADR    0x05    /* LED All Call I2C-bus address */
+#define PCA9685_REG_LED0_ON_L     0x06    /* LED0 on tick, low byte*/
+#define PCA9685_REG_LED0_ON_H     0x07    /* LED0 on tick, high byte*/
+#define PCA9685_REG_LED0_OFF_L    0x08    /* LED0 off tick, low byte */
+#define PCA9685_REG_LED0_OFF_H    0x09    /* LED0 off tick, high byte */
+// etc all 16:  LED15_OFF_H 0x45
+#define PCA9685_REG_ALLLED_ON_L   0xFA    /* load all the LEDn_ON registers, low */
+#define PCA9685_REG_ALLLED_ON_H   0xFB    /* load all the LEDn_ON registers, high */
+#define PCA9685_REG_ALLLED_OFF_L  0xFC    /* load all the LEDn_OFF registers, low */
+#define PCA9685_REG_ALLLED_OFF_H  0xFD    /* load all the LEDn_OFF registers,high */
+#define PCA9685_REG_PRESCALE      0xFE    /* Prescaler for PWM output frequency */
+#define PCA9685_REG_TESTMODE      0xFF    /* defines the test mode to be entered */
+
+/* PCA9685 MODE1 register bits */
+#define PCA9685_MODE1_ALLCAL      0x01    /* respond to LED All Call I2C-bus address */
+#define PCA9685_MODE1_SUB3        0x02    /* respond to I2C-bus subaddress 3 */
+#define PCA9685_MODE1_SUB2        0x04    /* respond to I2C-bus subaddress 2 */
+#define PCA9685_MODE1_SUB1        0x08    /* respond to I2C-bus subaddress 1 */
+#define PCA9685_MODE1_SLEEP       0x10    /* Low power mode. Oscillator off */
+#define PCA9685_MODE1_AI          0x20    /* Auto-Increment enabled */
+#define PCA9685_MODE1_EXTCLK      0x40    /* Use EXTCLK pin clock */
+#define PCA9685_MODE1_RESTART     0x80    /* Restart enabled */
+/* PCA9685 MODE2 register bits */
+#define PCA9685_MODE2_OUTNE_0     0x01    /* Active LOW output enable input */
+#define PCA9685_MODE2_OUTNE_1     0x02    /* Active LOW output enable input - high impedience */
+#define PCA9685_MODE2_OUTDRV      0x04    /* totem pole structure vs open-drain */
+#define PCA9685_MODE2_OCH         0x08    /* Outputs change on ACK vs STOP */
+#define PCA9685_MODE2_INVRT       0x10    /* Output logic state inverted */
+
+
+
+namespace as {
+
+template <byte ADDRESS=PCA9685_ADDRESS>
+class PCA9685 {
+  private:
+    static void writeRegister (uint8_t reg, uint8_t val) {
+      Wire.beginTransmission(ADDRESS);
+      Wire.write(reg);
+      Wire.write(val);
+      Wire.endTransmission();
+    }
+    static uint8_t readRegister (uint8_t reg) {
+      Wire.beginTransmission(ADDRESS);
+      Wire.write(adr);
+      Wire.endTransmission();
+      Wire.requestFrom(ADDRESS, 1);
+
+      int ret = -1;
+      if(Wire.available() <=1) {
+        ret = Wire.read();
+      }
+      return ret;
+    }
+
+  public:
+
+    void init () {
+      Wire.begin();
+      reset();
+    }
+
+    /* send reset command */
+    void reset () {
+      writeRegister (PCA9685_REG_MODE1, MODE1_RESTART);
+      delay(10);
+    }
+}
+
+
+}
+
+
+
+#endif /* ACTORS_PCA9685_H_ */

--- a/actors/PCA9685.h
+++ b/actors/PCA9685.h
@@ -59,7 +59,7 @@
 
 namespace as {
 
-template <byte ADDRESS=PCA9685_ADDRESS>
+template <uint8_t ADDRESS=PCA9685_ADDRESS>
 class PCA9685 {
   private:
     static void writeRegister (uint8_t reg, uint8_t val) {
@@ -70,7 +70,7 @@ class PCA9685 {
     }
     static uint8_t readRegister (uint8_t reg) {
       Wire.beginTransmission(ADDRESS);
-      Wire.write(adr);
+      Wire.write(reg);
       Wire.endTransmission();
       Wire.requestFrom(ADDRESS, 1);
 
@@ -116,7 +116,7 @@ class PCA9685 {
       writeRegister (PCA9685_REG_MODE1, PCA9685_MODE1_RESTART);
       delay(10);
     }
-}
+};
 
 
 }

--- a/actors/PCA9685.h
+++ b/actors/PCA9685.h
@@ -67,6 +67,7 @@ class PCA9685 {
       Wire.write(reg);
       Wire.write(val);
       Wire.endTransmission();
+//      DPRINT(F("###   write 0x"));DHEX(val);DPRINT(F(" to 0x"));DHEX(reg);DPRINTLN("");
     }
     static uint8_t readRegister (uint8_t reg) {
       Wire.beginTransmission(ADDRESS);
@@ -78,13 +79,24 @@ class PCA9685 {
       if(Wire.available() <=1) {
         ret = Wire.read();
       }
+//        DPRINT(F("###   read 0x"));DHEX((uint8_t)ret);DPRINT(F(" from 0x"));DHEX(reg);DPRINTLN("");
       return ret;
     }
 
   public:
 
     void init () {
+      uint8_t myReg;
       Wire.begin();
+      myReg = readRegister(PCA9685_REG_MODE1);
+      /* turn internal oscillator on */
+      myReg &= ~PCA9685_MODE1_SLEEP;
+      writeRegister(PCA9685_REG_MODE1, myReg);
+      DPRINT(F("PCA9685 MODE1: 0x"));
+      DHEX(readRegister(PCA9685_REG_MODE1));
+      DPRINT(F(" MODE2: 0x"));
+      DHEX(readRegister(PCA9685_REG_MODE2));
+      DPRINT("\n");
     }
 
     void set (uint8_t channel, uint16_t value) {
@@ -92,17 +104,20 @@ class PCA9685 {
       /* LEDx_OFF contains the timeslot where LED is turned OFF */
       /* timeslots count from 0 to 4095 */
       if (value == 0) {
+        DPRINT(F("### PCA9685 channel "));DDEC(channel);DPRINTLN(F(" full off"));
         writeRegister (PCA9685_REG_LEDx_OFF_H(channel), PCA9685_LEDx_FULL_OFF);
         //writeRegister (PCA9685_REG_LEDx_OFF_L(channel), 0);
         //writeRegister (PCA9685_REG_LEDx_ON_H(channel), 0);
         //writeRegister (PCA9685_REG_LEDx_ON_L(channel), 0);
       } else if (value == 0x0FFF) {
+        DPRINT(F("### PCA9685 channel "));DDEC(channel);DPRINTLN(F(" full on"));
         writeRegister (PCA9685_REG_LEDx_ON_H(channel), PCA9685_LEDx_FULL_ON);
         //writeRegister (PCA9685_REG_LEDx_ON_L(channel), 0);
         writeRegister (PCA9685_REG_LEDx_OFF_H(channel), 0);
         //writeRegister (PCA9685_REG_LEDx_OFF_L(channel), 0);
       } else {
         /* no delay, turn LED on in the first timeslot */
+        DPRINT(F("### PCA9685 channel "));DDEC(channel);DPRINT(F(" to "));DDEC(value);DPRINT(" (");DDEC(value/41);DPRINTLN("%)");
         writeRegister (PCA9685_REG_LEDx_ON_H(channel), 0);
         writeRegister (PCA9685_REG_LEDx_ON_L(channel), 0);
 

--- a/actors/PWM.h
+++ b/actors/PWM.h
@@ -103,19 +103,20 @@ public:
   void set(uint8_t value) {
     uint16_t duty = 0;
     if ( value == STEPS) {
-      duty = FREQU;
+      duty = 0x0FFF;
     }
     else if (value > 0) {
       // https://diarmuid.ie/blog/pwm-exponential-led-fading-on-arduino-or-other-platforms/
       // duty = pow(2,(value/R)) + 4;
       // duty = pow(2,(value/20.9)+6.5);
       // duty = pow(1.37,(value/15.0)+22.0)-500;
-      duty = pow(1.28,(value/13.0)+29.65)-1300;
+      //duty = pow(1.28,(value/13.0)+29.65)-1300;
       // http://harald.studiokubota.com/wordpress/index.php/2010/09/05/linear-led-fading/index.html
       //duty = exp(value/18.0) + 4;
+      duty = 1.0 * value * 4096 / STEPS;
     }
     // DDEC(pin);DPRINT(" - ");DDECLN(duty);
-    //pwmWrite(pin,duty);
+    PCA9685::set(pin,duty);
   }
 };
 

--- a/actors/PWM.h
+++ b/actors/PWM.h
@@ -10,7 +10,7 @@
 #include <Arduino.h>
 #include "PhaseCut.h"
 
-
+#include "actors/PCA9685.h"
 
 
 namespace as {
@@ -87,14 +87,17 @@ class ZC_Control {
 };
 #endif
 
-template<uint8_t STEPS=200,uint16_t FREQU=65535>
-class PWM16ext:PCA9685 {
+template<uint8_t STEPS=200,uint16_t FREQU=65535, uint8_t ADDRESS=PCA9685_ADDRESS>
+class PWM16ext {
+private:
+  PCA9685<ADDRESS> pca;
   uint8_t pin;
 public:
   PWM16ext () : pin(0) {}
   ~PWM16ext () {}
 
   void init(uint8_t p) {
+    pca.init();
     pin = p;
     //pinMode(pin, PWM);
     set(0);
@@ -116,7 +119,7 @@ public:
       duty = 1.0 * value * 4096 / STEPS;
     }
     // DDEC(pin);DPRINT(" - ");DDECLN(duty);
-    PCA9685::set(pin,duty);
+    pca.set(pin,duty);
   }
 };
 

--- a/actors/PWM.h
+++ b/actors/PWM.h
@@ -88,7 +88,7 @@ class ZC_Control {
 #endif
 
 template<uint8_t STEPS=200,uint16_t FREQU=65535>
-class PWM16ext {
+class PWM16ext:PCA9685 {
   uint8_t pin;
 public:
   PWM16ext () : pin(0) {}

--- a/actors/PWM.h
+++ b/actors/PWM.h
@@ -87,6 +87,39 @@ class ZC_Control {
 };
 #endif
 
+template<uint8_t STEPS=200,uint16_t FREQU=65535>
+class PWM16ext {
+  uint8_t pin;
+public:
+  PWM16ext () : pin(0) {}
+  ~PWM16ext () {}
+
+  void init(uint8_t p) {
+    pin = p;
+    //pinMode(pin, PWM);
+    set(0);
+  }
+
+  void set(uint8_t value) {
+    uint16_t duty = 0;
+    if ( value == STEPS) {
+      duty = FREQU;
+    }
+    else if (value > 0) {
+      // https://diarmuid.ie/blog/pwm-exponential-led-fading-on-arduino-or-other-platforms/
+      // duty = pow(2,(value/R)) + 4;
+      // duty = pow(2,(value/20.9)+6.5);
+      // duty = pow(1.37,(value/15.0)+22.0)-500;
+      duty = pow(1.28,(value/13.0)+29.65)-1300;
+      // http://harald.studiokubota.com/wordpress/index.php/2010/09/05/linear-led-fading/index.html
+      //duty = exp(value/18.0) + 4;
+    }
+    // DDEC(pin);DPRINT(" - ");DDECLN(duty);
+    //pwmWrite(pin,duty);
+  }
+};
+
+
 #ifdef ARDUINO_ARCH_STM32F1
 
 template<uint8_t STEPS=200,uint16_t FREQU=65535>

--- a/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
+++ b/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
@@ -48,7 +48,7 @@ typedef AvrSPI<10,11,12,13> SPIType;
 typedef Radio<SPIType,2> RadioType;
 typedef StatusLed<LED_PIN> LedType;
 typedef AskSin<LedType,NoBattery,RadioType> HalType;
-typedef DimmerChannel<HalType,PEERS_PER_CHANNEL,PWM16ext> ChannelType;
+typedef DimmerChannel<HalType,PEERS_PER_CHANNEL> ChannelType;
 typedef DimmerDevice<HalType,ChannelType,3,3> DimmerType;
 
 HalType hal;

--- a/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
+++ b/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
@@ -18,12 +18,16 @@
 // we use a Pro Mini
 // Arduino pin for the LED
 // D4 == PIN 4 on Pro Mini
-#define LED_PIN 4
+//#define LED_PIN 4
+// tmStamp
+#define LED_PIN 3
 // Arduino pin for the config button
 // B0 == PIN 8 on Pro Mini
-#define CONFIG_BUTTON_PIN 8
+//#define CONFIG_BUTTON_PIN 8
+// tmStamp
+#define CONFIG_BUTTON_PIN 4
 
-#define DIMMER_PIN 3
+#define DIMMER_PIN 1
 
 // number of available peers per channel
 #define PEERS_PER_CHANNEL 4

--- a/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
+++ b/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
@@ -13,6 +13,7 @@
 
 #include <Dimmer.h>
 
+#include <actors/PCA9685.h>
 
 // we use a Pro Mini
 // Arduino pin for the LED
@@ -47,7 +48,7 @@ typedef AvrSPI<10,11,12,13> SPIType;
 typedef Radio<SPIType,2> RadioType;
 typedef StatusLed<LED_PIN> LedType;
 typedef AskSin<LedType,NoBattery,RadioType> HalType;
-typedef DimmerChannel<HalType,PEERS_PER_CHANNEL> ChannelType;
+typedef DimmerChannel<HalType,PEERS_PER_CHANNEL,PWM16ext> ChannelType;
 typedef DimmerDevice<HalType,ChannelType,3,3> DimmerType;
 
 HalType hal;

--- a/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
+++ b/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
@@ -52,7 +52,7 @@ typedef DimmerDevice<HalType,ChannelType,3,3> DimmerType;
 
 HalType hal;
 DimmerType sdev(devinfo,0x20);
-DimmerControl<HalType,DimmerType,PWM8<> > control(sdev);
+DimmerControl<HalType,DimmerType,PWM16ext<> > control(sdev);
 ConfigToggleButton<DimmerType> cfgBtn(sdev);
 
 void setup () {


### PR DESCRIPTION
Hi,
@psi-4ward hatte den Vorschlag und mir ein PCA9685 Breakout-Board zur Verfügung gestellt.
Im ersten Test klappt das ganz gut :)

Nun meine Fragen:
1. ob das so in die Lib passen würde?
2. Und wie legt man die Beispiele am Besten an? In einem eigenen Ordner, analog zu den STM-Dimmern, oder per `#define`?
3. Was hat es mit der linearen und quadratischen Dimmkurve auf sich? Der Sourcecode ist da ein bisschen verwirrend, vieles ist auskommentiert. Der `HM-LC-Dim1PWM-CV` z.B. würde die Einstellung von linear/quadratisch sowie der Frequenz unterstützen, aber wie sieht es in der Lib aus?