### PR TITLE
add failure blink pattern, if c1101 init fails

### DIFF
--- a/AskSinPP.h
+++ b/AskSinPP.h
@@ -212,12 +212,12 @@ public:
     srand((unsigned int&)id);
     led.init();
     buzzer.init();
-    radio.init();
+    bool ccinitOK = radio.init();
     radio.enable();
     // start the system timer
     sysclock.init();
     // signal start to user
-    led.set(LedStates::welcome);
+    led.set(ccinitOK ? LedStates::welcome : LedStates::failure);
     // delay first send by random time
     radio.setSendTimeout((rand() % 3500)+1000);
   }

--- a/Led.cpp
+++ b/Led.cpp
@@ -10,7 +10,7 @@
 
 namespace as {
 
-const LedStates::BlinkPattern LedStates::single [8] PROGMEM = {
+const LedStates::BlinkPattern LedStates::single [9] PROGMEM = {
     {0, 0, {0 , 0 } },  // 0; define nothing
     {2, 20, {5, 5,} },  // 1; define pairing string
     {2, 1, {10, 1,} },   // 2; define send indicator
@@ -19,9 +19,10 @@ const LedStates::BlinkPattern LedStates::single [8] PROGMEM = {
     {6, 3, {5, 1, 1, 1, 1, 10} }, // 5; define battery low indicator
     {6, 1, {1, 1, 5, 1, 5, 10} }, // 6; define welcome indicator
     {2, 6, {2, 2, } },  // 7; key long indicator
+    {5, 1, {8, 4, 4, 4, 4} },  // 8; failure
 };
 
-const LedStates::BlinkPattern LedStates::dual1 [8] PROGMEM = {
+const LedStates::BlinkPattern LedStates::dual1 [9] PROGMEM = {
     {0, 0, {0 , 0 } },  // 0; define nothing
     {2, 20, {5, 5,} },  // 1; define pairing string
     {2, 1, {20, 1,} },   // 2; define send indicator
@@ -30,8 +31,9 @@ const LedStates::BlinkPattern LedStates::dual1 [8] PROGMEM = {
     {6, 3, {5, 1, 1, 1, 1, 10} }, // 5; define battery low indicator
     {6, 1, {1, 1, 5, 1, 5, 10} }, // 6; define welcome indicator
     {2, 6, {2, 2, } },  // 7; key long indicator
+    {5, 1, {8, 4, 4, 4, 4} },  // 8; failure
 };
-const LedStates::BlinkPattern LedStates::dual2 [8] PROGMEM = {
+const LedStates::BlinkPattern LedStates::dual2 [9] PROGMEM = {
     {0, 0, {0 , 0 } },  // 0; define nothing
     {2, 20, {5, 5,} },  // 1; define pairing string
     {2, 1, {20, 1,} },   // 2; define send indicator
@@ -40,6 +42,7 @@ const LedStates::BlinkPattern LedStates::dual2 [8] PROGMEM = {
     {6, 3, {5, 1, 1, 1, 1, 10} }, // 5; define battery low indicator
     {6, 1, {7, 0, 0, 6, 0, 10} }, // 6; define welcome indicator
     {2, 6, {2, 2, } },  // 7; key long indicator
+    {5, 1, {8, 4, 4, 4, 4} },  // 8; failure
 };
 
 }

--- a/Led.h
+++ b/Led.h
@@ -14,7 +14,7 @@ namespace as {
 class LedStates {
 public:
   enum Mode { nothing=0, pairing=1,send=2, ack=3,
-    nack=4, bat_low=5, welcome=6, key_long=7 };
+    nack=4, bat_low=5, welcome=6, key_long=7, failure=8 };
 
   struct BlinkPattern {
     uint8_t  length;
@@ -22,9 +22,9 @@ public:
     uint8_t  pattern[6];
   };
 
-  static const BlinkPattern single[8] PROGMEM;
-  static const BlinkPattern dual1[8] PROGMEM;
-  static const BlinkPattern dual2[8] PROGMEM;
+  static const BlinkPattern single[9] PROGMEM;
+  static const BlinkPattern dual1[9] PROGMEM;
+  static const BlinkPattern dual2[9] PROGMEM;
 };
 
 template <class PINTYPE=ArduinoPins>

--- a/Radio.h
+++ b/Radio.h
@@ -512,7 +512,7 @@ public:
     };
 
     bool initOK = true;
-    for (uint8_t i=0; i<sizeof(initVal); i+=2) {                    // write init value to TRX868
+    for (uint8_t i=0; i<sizeof(initVal); i+=2) { // write init value to TRX868
       bool initres = initReg(pgm_read_byte(&initVal[i]), pgm_read_byte(&initVal[i+1]));
       //if any initReg fails, initOK has to be false
       if (initres == false) initOK = false;


### PR DESCRIPTION
according to the default behavior of eq3 devices:
blink pattern  _long - short - short_ means "general device failure" or "error initializing TRX868 module"
<img width="430" alt="Bildschirmfoto 2020-06-29 um 15 08 12" src="https://user-images.githubusercontent.com/18190139/86009306-5b2fd980-ba1a-11ea-8c65-c46e3742f1de.png">
