### PR TITLE
make LibSPI class compatible with Adafruit BusIO library

### DIFF
--- a/Radio.h
+++ b/Radio.h
@@ -17,9 +17,11 @@
 #include "Message.h"
 #include "AlarmClock.h"
 
-#ifdef ARDUINO_ARCH_AVR
+#if defined ARDUINO_ARCH_AVR && !defined Adafruit_SPIDevice_h
   #include <util/delay.h>
   typedef uint8_t BitOrder;
+  #define SPI_BITORDER_MSBFIRST MSBFIRST
+  #define SPI_BITORDER_LSBFIRST LSBFIRST
 #endif
 
 // #define USE_CCA
@@ -255,7 +257,7 @@ public:
 
 #ifdef SPI_MODE0
 
-template <uint8_t CS,uint32_t CLOCK=2000000, BitOrder BITORDER=MSBFIRST, uint8_t MODE=SPI_MODE0>
+template <uint8_t CS,uint32_t CLOCK=2000000, BitOrder BITORDER=SPI_BITORDER_MSBFIRST, uint8_t MODE=SPI_MODE0>
 class LibSPI {
 
 public:

--- a/Radio.h
+++ b/Radio.h
@@ -20,6 +20,9 @@
 #if defined ARDUINO_ARCH_AVR && !defined Adafruit_SPIDevice_h
   #include <util/delay.h>
   typedef uint8_t BitOrder;
+#endif
+
+#ifndef Adafruit_SPIDevice_h
   #define SPI_BITORDER_MSBFIRST MSBFIRST
   #define SPI_BITORDER_LSBFIRST LSBFIRST
 #endif


### PR DESCRIPTION
Adafruit BusIO [defines its own struct](https://github.com/adafruit/Adafruit_BusIO/blob/master/Adafruit_SPIDevice.h#L16-L19) for `BitOrder`, so it is not compatible with `typedef uint8_t BitOrder;` in [Radio.h#L22](https://github.com/pa-pa/AskSinPP/blob/f43a56c3c216493ce9ca09dda00b8ca06e42baf1/Radio.h#L22)

