### PR TITLE
Make Bme280 sensor implementation operational

### DIFF
--- a/sensors/Bme280.h
+++ b/sensors/Bme280.h
@@ -28,6 +28,7 @@ class Bme280 : public Temperature, public Pressure, public Humidity {
 public:
   Bme280 () {}
   void init () {
+    Wire.begin();
     _present = _bme.begin();
     _bme.setSettings(settings);
   }


### PR DESCRIPTION
When using the current implementation of the Bme280 sensor with the example code located in `examples/HM-WDS40-TH-I` the serial output and the Homematic CCU does not show any temperature and humidity output from the sensor.

The root cause of not measuring any temperature is a missing initialization of the bus.

This Pull Request adds the initialization code for the I2C bus where the sensor is connected to.

I have tested the implementation in the following setup:

atmega 328p as Arduino Nano (5V).
 - configuration switch is connected to pin D8 of the atmega
 - Status LED connected to D4 and ground ( with an appropriate resistor connected between 5V and the LED)
 - The CC1101 Chip connected via D10-D13 to handle radio ( vin is connected to 3.3V)
 - The Bme280 chip is connected via pins SDA - A4 and SCL - A5, Vin = 5V

If there are coding rules I've missed or changes to be made on the code please let me know.


I'll be happy to receive your comments.
 
