### PR TITLE
power on/off the cc1101 vcc

### DIFF
--- a/AskSinPP.h
+++ b/AskSinPP.h
@@ -195,7 +195,7 @@ public:
   static uint8_t readPin(uint8_t pinnr,uint8_t enablenr=0,uint8_t ms=0) {
     uint8_t value=0;
     pinMode(pinnr,INPUT_PULLUP);
-    if( enablenr != 0 ) {
+    if( enablenr != 0 && enablenr != 0xff) {
       digitalWrite(enablenr,HIGH);
       if( ms != 0 ) {
         _delay_ms(ms);
@@ -204,7 +204,7 @@ public:
     value = digitalRead(pinnr);
     pinMode(pinnr,OUTPUT);
     digitalWrite(pinnr,LOW);
-    if( enablenr != 0 ) {
+    if( enablenr != 0 && enablenr != 0xff) {
       digitalWrite(enablenr,LOW);
     }
     return value;

--- a/Radio.h
+++ b/Radio.h
@@ -194,6 +194,12 @@ public:
     PINTYPE::setLow(MOSI);
   }
 
+  void deInit () {
+    PINTYPE::setInput(CS);
+    PINTYPE::setInput(MOSI);
+    PINTYPE::setInput(SCLK);
+  }
+
   void select () {
     PINTYPE::setLow(CS);
   }
@@ -271,6 +277,12 @@ public:
 #endif
     pinMode(CS, OUTPUT);
     SPI.begin();
+  }
+
+  void deInit () {
+    PINTYPE::setInput(CS);
+    PINTYPE::setInput(PIN_SPI_MOSI);
+    PINTYPE::setInput(PIN_SPI_SCK);
   }
 
   void select () {
@@ -420,6 +432,7 @@ public:
 #endif
 
     if (PWRPIN < 255) {
+      spi.deInit();
       digitalWrite(PWRPIN, HIGH);
     }
   }
@@ -427,6 +440,7 @@ public:
   void wakeup (bool flush) {
     if (PWRPIN < 255) {
       digitalWrite(PWRPIN, LOW);
+      spi.init();
       _delay_ms(10);
       init();
     }

--- a/Radio.h
+++ b/Radio.h
@@ -280,12 +280,15 @@ public:
   }
 
   void shutdown () {
+    SPI.end();
     pinMode(CS, INPUT);
 #if defined ARDUINO_ARCH_STM32 && defined STM32L1xx
     pinMode(PIN_SPI_MOSI, INPUT);
     pinMode(PIN_SPI_SCK, INPUT);
+#else
+    pinMode(MOSI, INPUT);
+    pinMode(SCK, INPUT);
 #endif
-    SPI.end();
   }
 
   void select () {

--- a/Radio.h
+++ b/Radio.h
@@ -281,8 +281,10 @@ public:
 
   void deInit () {
     pinMode(CS, INPUT);
+#if defined ARDUINO_ARCH_STM32 && defined STM32L1xx
     pinMode(CS, PIN_SPI_MOSI);
     pinMode(CS, PIN_SPI_SCK);
+#endif
   }
 
   void select () {

--- a/Radio.h
+++ b/Radio.h
@@ -434,14 +434,14 @@ public:
     spi.strobe(CC1101_SPWD);                // enter power down state
 #endif
 
-    if (PWRPIN < 255) {
+    if (PWRPIN < 0xff) {
       spi.shutdown();
       digitalWrite(PWRPIN, HIGH);
     }
   }
 
   void wakeup (bool flush) {
-    if (PWRPIN < 255) {
+    if (PWRPIN < 0xff) {
       digitalWrite(PWRPIN, LOW);
       _delay_ms(10);
       init();
@@ -490,7 +490,7 @@ public:
 
 
   bool init () {
-    if (PWRPIN < 255) {
+    if (PWRPIN < 0xff) {
       pinMode(PWRPIN, OUTPUT);
       digitalWrite(PWRPIN, LOW);
       _delay_ms(10);
@@ -797,7 +797,7 @@ protected:
 
 };
 
-template <class SPIType ,uint8_t GDO0, uint8_t PWRPIN=255, int SENDDELAY=100,class HWRADIO=CC1101<SPIType,PWRPIN> >
+template <class SPIType ,uint8_t GDO0, uint8_t PWRPIN=0xff, int SENDDELAY=100,class HWRADIO=CC1101<SPIType,PWRPIN> >
 class Radio : public HWRADIO {
 
   static void isr () {

--- a/Radio.h
+++ b/Radio.h
@@ -282,8 +282,8 @@ public:
   void deInit () {
     pinMode(CS, INPUT);
 #if defined ARDUINO_ARCH_STM32 && defined STM32L1xx
-    pinMode(CS, PIN_SPI_MOSI);
-    pinMode(CS, PIN_SPI_SCK);
+    pinMode(PIN_SPI_MOSI, INPUT);
+    pinMode(PIN_SPI_SCK, INPUT);
 #endif
   }
 

--- a/Radio.h
+++ b/Radio.h
@@ -194,7 +194,7 @@ public:
     PINTYPE::setLow(MOSI);
   }
 
-  void deInit () {
+  void shutdown () {
     PINTYPE::setInput(CS);
     PINTYPE::setInput(MOSI);
     PINTYPE::setInput(SCLK);
@@ -279,7 +279,7 @@ public:
     SPI.begin();
   }
 
-  void deInit () {
+  void shutdown () {
     pinMode(CS, INPUT);
 #if defined ARDUINO_ARCH_STM32 && defined STM32L1xx
     pinMode(PIN_SPI_MOSI, INPUT);
@@ -434,7 +434,7 @@ public:
 #endif
 
     if (PWRPIN < 255) {
-      spi.deInit();
+      spi.shutdown();
       digitalWrite(PWRPIN, HIGH);
     }
   }
@@ -442,7 +442,6 @@ public:
   void wakeup (bool flush) {
     if (PWRPIN < 255) {
       digitalWrite(PWRPIN, LOW);
-      spi.init();
       _delay_ms(10);
       init();
     }

--- a/Radio.h
+++ b/Radio.h
@@ -285,6 +285,7 @@ public:
     pinMode(PIN_SPI_MOSI, INPUT);
     pinMode(PIN_SPI_SCK, INPUT);
 #endif
+    SPI.end();
   }
 
   void select () {

--- a/Radio.h
+++ b/Radio.h
@@ -280,9 +280,9 @@ public:
   }
 
   void deInit () {
-    PINTYPE::setInput(CS);
-    PINTYPE::setInput(PIN_SPI_MOSI);
-    PINTYPE::setInput(PIN_SPI_SCK);
+    pinMode(CS, INPUT);
+    pinMode(CS, PIN_SPI_MOSI);
+    pinMode(CS, PIN_SPI_SCK);
   }
 
   void select () {


### PR DESCRIPTION
Wir hatten ja schon mal darüber gesprochen, das CC1101 komplett abzuschalten.
Beim HM-RC-4 ATmega168 Code hatte ich es quick&dirty im Projekt umgesetzt.

Nun habe ich hier den RWE WDS (Fensterkontakt) und dort wieder das Problem, dass VCC am TRX-Modul abgeschaltet werden muss.

Mein Code ist sicher überarbeitungswürdig, aber ich hätte es trotzdem gern mit in der AskSinPP Lib, damit ich nicht zum Sketch noch auf den von mir angepassten Fork verweisen müsste.