### PR TITLE
add init() method without parameter

### DIFF
--- a/BatterySensor.h
+++ b/BatterySensor.h
@@ -415,7 +415,11 @@ public:
   void init(__attribute__((unused)) uint32_t period,__attribute__((unused)) AlarmClock& clock) {
     unsetIdle();
   }
-
+  
+  void init() {
+    init(0,sysclock);
+  }
+  
   /**
    * Disable the continues battery measurement
    * Called by HAL before enter idle/sleep state
@@ -468,7 +472,11 @@ public:
     pinMode(SENSPIN, INPUT);
     unsetIdle();
   }
-
+  
+  void init() {
+    init(0,sysclock);
+  }
+  
   uint16_t getInternalVcc() {
     //read internal Vcc as reference voltage
     ADMUX &= ~(ADMUX_REFMASK | ADMUX_ADCMASK);

--- a/BatterySensor.h
+++ b/BatterySensor.h
@@ -412,13 +412,14 @@ public:
    * \param period ticks until next measurement
    * \param clock clock to use for waiting
    */
-  void init(__attribute__((unused)) uint32_t period,__attribute__((unused)) AlarmClock& clock) {
+  void init() {
     unsetIdle();
   }
   
-  void init() {
-    init(0,sysclock);
+  void init(__attribute__((unused)) uint32_t period,__attribute__((unused)) AlarmClock& clock) {
+    init();
   }
+
   
   /**
    * Disable the continues battery measurement
@@ -468,13 +469,14 @@ public:
    * \param period ticks until next measurement
    * \param clock clock to use for waiting
    */
-  void init(__attribute__((unused)) uint32_t period,__attribute__((unused)) AlarmClock& clock) {
+   
+  void init() {
     pinMode(SENSPIN, INPUT);
     unsetIdle();
   }
   
-  void init() {
-    init(0,sysclock);
+  void init(__attribute__((unused)) uint32_t period,__attribute__((unused)) AlarmClock& clock) {
+    init();
   }
   
   uint16_t getInternalVcc() {


### PR DESCRIPTION
Können wir noch eine parameterlose `init()` für die Irq Batt einfügen?
Da weder Intervall noch Clock benötigt werden, sieht es im Sketch schöner aus, wenn man da nur `hal.battery.init();` aufrufen kann.

Oder ist das problematisch, wenn es die `init()` nicht in allen Batterie-Klassen gibt?