### PR TITLE
Simulated keypress implementation

### DIFF
--- a/Dimmer.h
+++ b/Dimmer.h
@@ -814,18 +814,18 @@ public:
         dimmer.dimmerChannel(j).setLevel(0, 0, 0xffff);
 
         bool powerup = dimmer.dimmerChannel(j).getList1().powerUpAction();
-        Peer xwnID(1);
-        dimmer.getDeviceID(xwnID);
-        DimmerList3 l3 = dimmer.dimmerChannel(j).getList3(xwnID);
-        //DPRINT(F("init cnl ")); DPRINT(j);
+        Peer ownID(1);
+        dimmer.getDeviceID(ownID);
+        DimmerList3 l3 = dimmer.dimmerChannel(j).getList3(ownID);
+        DPRINT(F("init cnl ")); DPRINT(j);
 
         if (powerup == true && l3.valid() == true) {
-          //DPRINTLN(F(", powerup"));
+          DPRINTLN(F(", powerup"));
           typename DimmerList3::PeerList pl = l3.sh();
           //  pl.dump();
           dimmer.dimmerChannel(j).remote(pl, 1);
         } else {
-          //DPRINTLN(F(", set level 0"));
+          DPRINTLN(F(", set level 0"));
         }
       }
     }

--- a/Message.h
+++ b/Message.h
@@ -42,6 +42,7 @@ class SerialInfoMsg;
 class DeviceInfoMsg;
 class RemoteEventMsg;
 class SensorEventMsg;
+class SwitchSimMsg;
 class ActionMsg;
 class ActionSetMsg;
 class ActionCommandMsg;
@@ -380,7 +381,8 @@ public:
   const ConfigWriteIndexMsg& configWriteIndex () const { return *(ConfigWriteIndexMsg*)this; }
 
   const RemoteEventMsg& remoteEvent () const { return *(RemoteEventMsg*)this; }
-  const SensorEventMsg& sensorEvent () const { return *(SensorEventMsg*)this; }
+  const SensorEventMsg& sensorEvent() const { return *(SensorEventMsg*)this; }
+  const SwitchSimMsg& switchSim () const { return *(SwitchSimMsg*)this; }
   const ActionMsg& action () const { return *(ActionMsg*)this; }
   const ActionSetMsg& actionSet () const { return *(ActionSetMsg*)this; }
   const ActionCommandMsg& actionCommand () const { return *(ActionCommandMsg*)this; }
@@ -494,6 +496,27 @@ public:
   }
   uint8_t value () const { return *data(); }
 };
+
+class SwitchSimMsg : public Message {
+protected:
+  SwitchSimMsg() {}
+  //       00 01 02 030405 060708 09 10 11 12 13 14
+  // -> 0F 72 A0 3E 4C3CDF 952A73 95 2A 73 40 01 53 - 726356
+  //    3E			Switch - Simulierter Tastendruck
+  //    4C3CDF		From
+  //    952A73		To
+  //    95 2A 73	Zu simulierender Absender
+  //    40			Remote Message soll simuliert werden
+  //    01			Kanal 1
+  //    53			Zähler
+
+public:
+  HMID fromSim() const { return HMID(buffer()[9], buffer()[10], buffer()[11]); }
+  Peer peer() const { return Peer(fromSim(), buffer()[13] & 0x3f); }
+  uint8_t counter() const { return buffer()[14]; }
+  uint8_t msg_type() const { return buffer()[12]; }
+};
+
 
 class ActionMsg : public Message {
 protected:

--- a/Message.h
+++ b/Message.h
@@ -511,10 +511,23 @@ protected:
   //    53			Zähler
 
 public:
-  HMID fromSim() const { return HMID(buffer()[9], buffer()[10], buffer()[11]); }
-  Peer peer() const { return Peer(fromSim(), buffer()[13] & 0x3f); }
-  uint8_t counter() const { return buffer()[14]; }
+  //HMID fromSim() const { return HMID(buffer()[9], buffer()[10], buffer()[11]); }
+  //Peer peer() const { return Peer(fromSim(), buffer()[13] & 0x3f); }
+  //uint8_t counter() const { return buffer()[14]; }
   uint8_t msg_type() const { return buffer()[12]; }
+
+  RemoteEventMsg& toEventMsg() const {
+    RemoteEventMsg& pm = *(RemoteEventMsg*)&pload[10]; // use last 20 byte for simulated message
+    pm.length(9);
+    pm.flags(Message::BCAST);
+    pm.type(msg_type());
+    pm.from((uint8_t*)buffer()+9);
+    pm.to((uint8_t*)buffer() + 6);
+    pm.append((uint8_t*)buffer() + 13, 2);
+    return pm;
+  }
+
+
 };
 
 

--- a/MultiChannelDevice.h
+++ b/MultiChannelDevice.h
@@ -415,23 +415,13 @@ public:
        }
 #ifndef SENSOR_ONLY
        else if (mtype == AS_MESSAGE_SWITCH_EVENT) {
-         uint8_t msg_type = msg.switchSim().msg_type();
-         RemoteEventMsg pm = msg.remoteEvent();
-
-         pm.length(9);
-         pm.type(msg_type);
-         pm.from(&msg.buffer()[9]);
-         pm.command(msg.buffer()[13]);
-         pm.flags(Message::BCAST);
-         pm.append(msg.buffer() + 13, 2);
-
-         DPRINT("X> "); pm.dump();
+         RemoteEventMsg& pm = msg.switchSim().toEventMsg();
+         //DPRINT("X> "); pm.dump();
 
          for (uint8_t cdx = 1; cdx <= this->channels(); ++cdx) {
            ChannelType* c = &channel(cdx);
-           DPRINT("cnl: "); DPRINTLN(cdx);
+           //DPRINT("cnl: "); DPRINTLN(cdx);
            if (c->inhibit() == false && c->has(pm.peer()) == true) {
-             DPRINTLN("we are in");
              c->process(pm);
            }
          }


### PR DESCRIPTION
CCU backend offers the option to check the internal key setup by sending a "simulierter Tastendruck".
The other option is at the direct link setup page - called "Empfänger Profil testen"

This both options are generating a Switch message which is send to the actor. The message needs to be processed in the actor as remote event message.

a big thanks to papa for his optimization hints!