### PR TITLE
update sketch test

### DIFF
--- a/.github/workflows/build-sketches.yml
+++ b/.github/workflows/build-sketches.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup Arduino CLI
         uses: arduino/setup-arduino-cli@v1.1.1
+        with:
+          version: "0.17.0"
 
       - name: Install Libs and Cores
         run: ./install-deps.sh

--- a/.github/workflows/tests/download-sketches.sh
+++ b/.github/workflows/tests/download-sketches.sh
@@ -19,6 +19,7 @@ GIT_REPOS=(
   "https://github.com/jp112sdl/HB-UNI-Sen-CURRENT.git"
   "https://github.com/jp112sdl/HB-UNI-Sen-CAP-MOIST.git"
   "https://github.com/jp112sdl/HB-RC-2-PBU-LED.git"
+  "https://github.com/jp112sdl/HB-RC-6-PBU-LED.git"
   "https://github.com/jp112sdl/HB-UNI-RGB-LED-CTRL.git"
   "https://github.com/jp112sdl/HB-UNI-SenAct-4-4.git"
   "https://github.com/jp112sdl/HB-UNI-DMX-MASTER.git"


### PR DESCRIPTION
- fix arduino cli version; set to 0.17.0
- in 0.18.0 they added  "library validation step when installing from zip or git" which causes errors and needs further investigation
  - https://github.com/arduino/arduino-cli/releases/tag/0.18.0