### PR TITLE
FreqTest improvements

### DIFF
--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -154,10 +154,15 @@ public:
         // store frequency
         DPRINT("Store into config area: ");DHEX((uint8_t)(freq>>8));DHEX((uint8_t)(freq&0xff));
         StorageConfig sc = getConfigArea();
+
 #if defined ARDUINO_ARCH_STM32F1
         Wire.begin();
         DPRINT(".");
 #endif
+        // read old frequency
+        uint8_t oldF1 = sc.getByte(CONFIG_FREQ1);
+        uint8_t oldF2 = sc.getByte(CONFIG_FREQ2);
+
         sc.clear();
         DPRINT(".");
         sc.setByte(CONFIG_FREQ1, freq>>8);
@@ -167,6 +172,10 @@ public:
         sc.validate();
 
         DPRINTLN("stored!");
+
+        DPRINT("\nOld Config Freq was: 0x21");DHEX(oldF1);DHEX(oldF2);
+        printFreq(0x210000 + oldF1*256 + oldF2);
+
 #if defined ARDUINO_ARCH_STM32F1
         // measurement is done, loop here forever
         while(1);

--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -173,9 +173,11 @@ public:
 
         DPRINTLN("stored!");
 
-        DPRINT("\nOld Config Freq was: 0x21");DHEX(oldF1);DHEX(oldF2);
-        printFreq(0x210000 + oldF1*256 + oldF2);
-
+        if ((oldF1 >= 0x60) && (oldF1 <= 0x6A)) {
+          DPRINT("\nOld Config Freq was: 0x21");DHEX(oldF1);DHEX(oldF2);
+          printFreq(0x210000 + oldF1*256 + oldF2);
+        }
+        
 #if defined ARDUINO_ARCH_STM32F1
         // measurement is done, loop here forever
         while(1);

--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -180,6 +180,8 @@ public:
         // measurement is done, loop here forever
         while(1);
 #else
+        DPRINTLN("Going to sleep...");
+        Serial.flush();
         activity().savePower<Sleep<> >(this->getHal());
 #endif
       }

--- a/examples/FreqTest/FreqTest.ino
+++ b/examples/FreqTest/FreqTest.ino
@@ -193,9 +193,14 @@ public:
   virtual bool process(Message& msg) {
     msg.from().dump(); DPRINT(".");
     rssi = max(rssi,radio().rssi());
-    received++;
-    if( received > 0 ) {
-      trigger(sysclock);
+#ifdef ACTIVE_PING
+    if (msg.from() == PING_TO)
+#endif
+    {
+      received++;
+      if( received > 0 ) {
+        trigger(sysclock);
+      }
     }
     return true;
   }
@@ -205,6 +210,12 @@ public:
     this->getDeviceID(id);
     hal.init(id);
 
+#ifdef ACTIVE_PING
+    DPRINT("Active ping is enabled, looking for telegrams only from ");
+    PING_TO.dump(); DPRINTLN("!");
+#else
+    DPRINTLN("Active ping is NOT enabled, looking for any telegram");
+#endif
     DPRINTLN("Start searching ...");
     setFreq(STARTFREQ);
     return false;


### PR DESCRIPTION
Few improvements for the FreqTest:

### 1. Show previous frequency:
I had to calibrate few times to figure out other trouble, and would like to see if the newly calibrated frequency is close to the previous calibration or not.

Example output:
```
Done: 0x2165AA - 0x21664A
Calculated Freq: 0x2165FA 868.357 MHz
Store into config area: 65FA....stored!

Old Config Freq was: 0x21660A 868.363 MHz
```

### 2. ACTIVE_PING shall only used direct answers
Because of the [RPI-RF-MOD frequency shift](https://homematic-forum.de/forum/viewtopic.php?f=76&t=63125) I wanted to calibrate against the answer telegrams from the CCU, and not other devices that are probably shifted as well.

Example output:
```
AskSin++ v5.0.0 (Apr 16 2021 12:55:14)
CC init1
CC Version: 04
 - ready
Active ping is enabled, looking for telegrams only from 2D7DD5!
Start searching ...
Freq 0x21656A 868.300 MHz:   0
Freq 0x2165BA 868.332 MHz: 25EECF.25EECF.  0
Freq 0x21651A 868.268 MHz:   0
Freq 0x21660A 868.363 MHz: 2D7DD5.  1 / -95dBm
Search for upper bound
Freq 0x21661A 868.370 MHz: 2D7DD5.  1 / -95dBm
Freq 0x21662A 868.376 MHz: 2D7DD5.  1 / -95dBm
Freq 0x21663A 868.382 MHz: 2D7DD5.  1 / -94dBm
Freq 0x21664A 868.389 MHz: 2D7DD5.  1 / -96dBm
Freq 0x21665A 868.395 MHz:   0
Search for lower bound
Freq 0x2165FA 868.357 MHz: 3AEA30.2D7DD5.  1 / -96dBm
Freq 0x2165EA 868.351 MHz: 2D7DD5.  1 / -96dBm
Freq 0x2165DA 868.344 MHz: 00AC04.2D7DD5.  1 / -97dBm
Freq 0x2165CA 868.338 MHz: 2D7DD5.  1 / -97dBm
Freq 0x2165BA 868.332 MHz: 2D7DD5.  1 / -95dBm
Freq 0x2165AA 868.325 MHz: 44B439.25EECF.  0

Done: 0x2165BA - 0x21664A
Calculated Freq: 0x216602 868.360 MHz
Store into config area: 6602....stored!

Old Config Freq was: 0x2165FA 868.357 MHz
```