### PR TITLE
Feature/switch add status info min dly

### DIFF
--- a/Register.h
+++ b/Register.h
@@ -60,7 +60,7 @@ namespace as {
 #define CREG_STATUSINFO 0x57
 #define CREG_CHARACTERISTIC 0x58                 // index="88" size="0.1"
 #define CREG_CHARACTERISTIC_LEVELLIMIT 0x58      // index="88.1" size="0.1"
-#define CREG_HARACTERISTIC_COLOURASSIGNMENT 0x58 // index="88.2" size="0.1"
+#define CREG_CHARACTERISTIC_COLOURASSIGNMENT 0x58// index="88.2" size="0.1"
 #define CREG_CHARACTERISTIC_BASETYPE 0x58        // index="88.4" size="0.4"
 #define CREG_LOGICCOMBINATION 0x59
 #define CREG_TX_MINDELAY 0x7b
@@ -513,7 +513,7 @@ public:
 
 //#define CREG_CHARACTERISTIC 0x58                 // index="88" size="0.1"
 //#define CREG_CHARACTERISTIC_LEVELLIMIT 0x58      // index="88.1" size="0.1"
-//#define CREG_HARACTERISTIC_COLOURASSIGNMENT 0x58 // index="88.2" size="0.1"
+//#define CREG_CHARACTERISTIC_COLOURASSIGNMENT 0x58// index="88.2" size="0.1"
 //#define CREG_CHARACTERISTIC_BASETYPE 0x58        // index="88.4" size="0.4"
 
 


### PR DESCRIPTION
Können wir die "Status Mindestverzögerung" so auch in die `Switch.h` mit einbauen (wie bei `Dimmer.h` und `Blind.h`) ?
_P.S.: Der typo fix in der Register.h sollte hier eigentlich gar nicht mit rein._