### PR TITLE
don't set WORKING if brightness was changed locally

### DIFF
--- a/Dimmer.h
+++ b/Dimmer.h
@@ -426,7 +426,7 @@ public:
     calarm.setflag(value,ERRORREDUCED);
   }
   bool getoverload(){
-	  return calarm.hasflag(ERROROVERLOAD);
+    return calarm.hasflag(ERROROVERLOAD);
   }
 
   void setup(DimmerList1 l1) {
@@ -669,17 +669,19 @@ public:
     if( calarm.hasflag(ERROROVERHEAT) == true ) {
       f |= AS_CM_EXTSTATE_OVERHEAT;
     }
-	if( calarm.hasflag(ERROROVERLOAD) == true ) {
-	  f |= AS_CM_EXTSTATE_OVERLOAD;
-	}
+    if( calarm.hasflag(ERROROVERLOAD) == true ) {
+      f |= AS_CM_EXTSTATE_OVERLOAD;
+    }
     if( calarm.hasflag(ERRORREDUCED) == true ) {
       f |= AS_CM_EXTSTATE_REDUCED;
     }
-    if( alarm.destlevel < level) {
-      f |= AS_CM_EXTSTATE_DOWN;
-    }
-    else if( alarm.destlevel > level) {
-      f |= AS_CM_EXTSTATE_UP;
+    if( alarm.active()) {
+      if( alarm.destlevel < level) {
+        f |= AS_CM_EXTSTATE_DOWN;
+      }
+      else if( alarm.destlevel > level) {
+        f |= AS_CM_EXTSTATE_UP;
+      }
     }
     return f;
   }


### PR DESCRIPTION
fixes #155

`alarm.destlevel` keeps the previous value if the brightness is changed locally on the device, so the flags were calculated in a wrong way.
Fix: check `alarm.destlevel` only if an alarm is active.