### PR TITLE
STM32 HM-LC-Dim1PWM-CV: fix number of channels

### DIFF
--- a/examples/stm32/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
+++ b/examples/stm32/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino
@@ -61,7 +61,7 @@ const struct DeviceInfo PROGMEM devinfo = {
 typedef LibSPI<PA4> RadioSPI;
 typedef AskSin<StatusLed<LED_BUILTIN>,NoBattery,Radio<RadioSPI,PB0> > HalType;
 typedef DimmerChannel<HalType,PEERS_PER_CHANNEL> ChannelType;
-typedef DimmerDevice<HalType,ChannelType,6,3> DimmerType;
+typedef DimmerDevice<HalType,ChannelType,3,3> DimmerType;
 
 HalType hal;
 DimmerType sdev(devinfo,0x20);


### PR DESCRIPTION
3 channels in total, 3 virtual channel --> 1 physical channel

same as 
https://github.com/pa-pa/AskSinPP/blob/master/examples/STM32Lxx/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino#L58
https://github.com/pa-pa/AskSinPP/blob/master/examples/HM-LC-Dim1PWM-CV/HM-LC-Dim1PWM-CV.ino#L52