### PR TITLE
add "stm32" for STM32L1 to the list of supported platforms

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Homematic Protocol Library
 paragraph=Homematic Protocol Library
 category=Communication
 url=https://github.com/pa-pa/AskSinPP
-architectures=avr,STM32F1,esp32
+architectures=avr,STM32F1,stm32,esp32
 depends=EnableInterrupt,Low-Power


### PR DESCRIPTION
avoids this warning:
WARNUNG: Bibliothek AskSinPP-master behauptet auf avr, STM32F1, esp32 Architektur(en) ausgeführt werden zu können und ist möglicherweise inkompatibel mit Ihrem derzeitigen Board, welches auf stm32 Architektur(en) ausgeführt wird.