### PR TITLE
Dev rp2040

### DIFF
--- a/Activity.h
+++ b/Activity.h
@@ -379,14 +379,18 @@ public:
   }
 };
 
-#ifdef ARDUINO_ARCH_ESP32
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040)
 class Sleep {
 public:
   static uint32_t doSleep (uint32_t ticks) {
     uint32_t sleeptime = ticks2millis(ticks);
 
+#ifdef ARDUINO_ARCH_RP2040
+    sleep_ms(sleeptime); // https://raspberrypi.github.io/pico-sdk-doxygen/group__sleep.html
+#else
     esp_sleep_enable_timer_wakeup(sleeptime * 100000);
     esp_light_sleep_start();
+#endif
 
     return ticks;
   }

--- a/Activity.h
+++ b/Activity.h
@@ -382,7 +382,7 @@ public:
 #if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040)
 class Sleep {
 public:
-  static uint32_t doSleep (uint32_t ticks) {
+  static void doSleep (uint32_t ticks) {
     uint32_t sleeptime = ticks2millis(ticks);
 
 #ifdef ARDUINO_ARCH_RP2040
@@ -392,33 +392,25 @@ public:
     esp_light_sleep_start();
 #endif
 
-    return ticks;
   }
 
   static void waitSerial() {Serial.flush();};
 
   template <class Hal>
   static void powerSave (Hal& hal) {
-    sysclock.disable();
     uint32_t ticks = sysclock.next();
     if( sysclock.isready() == false ) {
       if( ticks == 0 || ticks > millis2ticks(15) ) {
         hal.radio.setIdle();
-        uint32_t offset = doSleep(ticks);
-        sysclock.correct(offset);
-        sysclock.enable();
+        doSleep(ticks);
       }
       else{
-        sysclock.enable();
-//        Idle<ENABLETIMER2>::powerSave(hal);
         powerSave(hal);
       }
     }
-    else {
-      sysclock.enable();
-    }
   }
 };
+
 #endif
 
 }

--- a/AlarmClock.h
+++ b/AlarmClock.h
@@ -10,6 +10,9 @@
 #include "Alarm.h"
 
 #ifdef ARDUINO_ARCH_RP2040
+  #include "hardware/rtc.h"
+  #include "pico/stdlib.h"
+  #include "pico/util/datetime.h"
 #endif
 
 namespace as {
@@ -268,6 +271,13 @@ public:
 #elif defined(ARDUINO_ARCH_STM32F1) && defined(_RTCLOCK_H_)
     rt = RTClock(RTCSEL_LSE);
     rt.attachSecondsInterrupt(rtccallback);
+#elif defined(ARDUINO_ARCH_RP2040)
+    datetime_t alarmT;
+    rtc_init();
+    rtc_get_datetime(&alarmT);
+    alarmT.min = alarmT.hour = alarmT.day = alarmT.dotw = alarmT.month = alarmT.year = -1;
+    alarmT.sec =  1;
+    rtc_set_alarm(&alarmT, rtccallback); // https://raspberrypi.github.io/pico-sdk-doxygen/group__hardware__rtc.html
 #else
   #warning "RTC not supported"
 #endif

--- a/AlarmClock.h
+++ b/AlarmClock.h
@@ -211,8 +211,9 @@ public:
       timerAlarmEnable(Timer);
   #endif
   #ifdef ARDUINO_ARCH_RP2040
-    cancel_repeating_timer(&rp2040_timer);
-    add_repeating_timer_us(10000UL, TimerHandler, NULL, &rp2040_timer);
+    if (rp2040_timer.alarm_id < 1) {
+      add_repeating_timer_us(10000UL, TimerHandler, NULL, &rp2040_timer);
+    }
   #endif
   }
 

--- a/AlarmClock.h
+++ b/AlarmClock.h
@@ -10,8 +10,6 @@
 #include "Alarm.h"
 
 #ifdef ARDUINO_ARCH_RP2040
-  //https://github.com/khoih-prog/RPI_PICO_TimerInterrupt
-  #include "RPi_Pico_TimerInterrupt.h"
 #endif
 
 namespace as {
@@ -112,9 +110,9 @@ class SysClock : public AlarmClock {
 #endif
 
 #ifdef ARDUINO_ARCH_RP2040
-  RPI_PICO_Timer ITimer0 = 0;
 private:
-  static bool TimerHandler0(__attribute__((unused)) struct repeating_timer *t) { callback(); return true; }
+  struct repeating_timer  rp2040_timer;
+  static bool TimerHandler(__attribute__((unused)) struct repeating_timer *t) { callback(); return true; }
 #endif
 public:
   static SysClock& instance();
@@ -191,7 +189,7 @@ public:
       timerAlarmDisable(Timer);
   #endif
   #ifdef ARDUINO_ARCH_RP2040
-    ITimer0.detachInterrupt();
+    cancel_repeating_timer(&rp2040_timer);
   #endif
   }
 
@@ -210,7 +208,8 @@ public:
       timerAlarmEnable(Timer);
   #endif
   #ifdef ARDUINO_ARCH_RP2040
-    ITimer0.attachInterruptInterval(10000UL, TimerHandler0);
+    cancel_repeating_timer(&rp2040_timer);
+    add_repeating_timer_us(10000UL, TimerHandler, NULL, &rp2040_timer);
   #endif
   }
 

--- a/AskSinPP.h
+++ b/AskSinPP.h
@@ -305,6 +305,9 @@ public:
 
   void sleepForever () { activity.sleepForever(*this); }
 #endif
+#if defined(ARDUINO_ARCH_RP2040)
+  void sleep () { activity.savePower<Sleep>(*this); }
+#endif
 };
 
 #ifndef NORTC

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ C++ implementation of the AskSin protocol
   - For ATMega644 and ATMega1284 the PR #49 needs to be included
 - [Low-Power](https://github.com/rocketscream/Low-Power.git)
   - For ATMega644 and ATMega1284 the PR #57 needs to be included
-- [RPI_PICO_TimerInterrupt](https://github.com/khoih-prog/RPI_PICO_TimerInterrupt)
-  - For RP2040 (i.e. Raspberry Pi Pico)
 
 ## Optional required Sensor Libraries
 - [Sensor Base Library](https://github.com/adafruit/Adafruit_Sensor)

--- a/Radio.h
+++ b/Radio.h
@@ -19,7 +19,7 @@
   typedef uint8_t BitOrder;
 #endif
 
-#if defined ARDUINO_ARCH_RP2040
+#if (defined ARDUINO_ARCH_RP2040) && (defined _HARDWARE_SPI_H)
   #define SPI_MODE0     0
 #endif
 

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Homematic Protocol Library
 paragraph=Homematic Protocol Library
 category=Communication
 url=https://github.com/pa-pa/AskSinPP
-architectures=avr,STM32F1,stm32,esp32
+architectures=avr,STM32F1,stm32,esp32,rp2040
 depends=EnableInterrupt,Low-Power


### PR DESCRIPTION
- Abhängigkeit der `RPI_PICO_TimerInterrupt` Lib entfernt
- `rp2040` in `library.properties` als Zielplatform hinzugefügt
- `sleep()` Methode hinzugefügt
  - _Die sysclock muss im sleep nicht disabled werden, da der interne Timer im sleep angehalten wird._