### PR TITLE
some smaller updates

### DIFF
--- a/Debug.h
+++ b/Debug.h
@@ -113,6 +113,24 @@
   inline void DDECLN(TYPE b) { DDEC(b); DPRINT(F("\r\n")); }
   inline void DHEXLN(const uint8_t* b,uint8_t l) { DHEX(b,l); DPRINT(F("\r\n")); }
 
+  #define DDEVLISTS(dev) \
+    uint8_t cnls = dev.channels(); \
+    DPRINT(F("channels: ")); DPRINTLN(cnls); \
+    GenericList l = dev.getList0(); \
+    DPRINT(F("cnl0, lst0: ")); l.dump(); DPRINT(F("\r\n")); \
+    for (uint8_t i = 1; i <= cnls; ++i) { \
+      l = dev.channel(i).getList1(); \
+      DPRINT(F("cnl")); DPRINT(i); DPRINT(F(", lst1: ")); l.dump(); \
+      uint8_t peers = dev.channel(i).peers(); \
+      DPRINT(F("peers: ")); DPRINTLN(peers); \
+      for (uint8_t j = 0; j < peers; ++j) { \
+        Peer p = dev.channel(i).peerat(j); \
+        GenericList l = dev.channel(i).getList3(j); \
+        DPRINT(j); DPRINT(F(": ")); p.dump(); DPRINT(F(": ")); l.dump(); DPRINT(F("\r\n")); \
+      } \
+    } \
+
+
 #endif
 
 #endif

--- a/Motion.h
+++ b/Motion.h
@@ -93,6 +93,7 @@ private:
   volatile bool    isrenabled : 1;
   BrightnessSensor brightsens;
   uint32_t         maxbright;
+  uint16_t         ledontime;
 
 public:
   typedef Channel<HalType,MotionList1,EmptyList,DefList4,PeerCount,List0Type> ChannelType;
@@ -161,9 +162,6 @@ public:
       sysclock.add(quiet);
       // blink led
       if( this->device().led().active() == false ) {
-        //this->device().led().ledOn(centis2ticks(this->getList1().ledOntime()) / 2);
-        uint16_t ledontime = this->getList1().ledOntime();
-        DPRINT(F("ledontime: ")); DPRINTLN(ledontime);
         this->device().led().ledOn(centis2ticks(ledontime) / 2);
       }
       MotionEventMsg& msg = (MotionEventMsg&)this->device().message();
@@ -192,6 +190,13 @@ public:
   // we are in quiet mode - means we have a motion detected
   bool isMotion () const {
     return quiet.enabled == true;
+  }
+
+  void configChanged () {
+    uint16_t ledontime = this->getList1().ledOntime();
+    //DPRINT(F("cc ledontime: ")); DPRINTLN(ledontime);
+    if (ledontime) this->device().led().stealth(0);
+    else this->device().led().stealth(1);
   }
 
 };


### PR DESCRIPTION
led off for motion sensor

There is a "LED-Leuchtzeit (gn/rt)" setting   which sets the led on duration if a motion was recognised.
The value can be 0 as well, which shall switch off the led, but the led was still blinking for the transition.
My changes ensure on a 0 value that the led is switched off…

update on debug.h

Tool to debug list settings
DDEVLISTS(sdev) prints all List's of a device
