### PR TITLE
Add files via upload

### DIFF
--- a/Remote.h
+++ b/Remote.h
@@ -49,7 +49,7 @@ public:
   uint8_t flags () const {
     return 0;
   }
-  
+
   void repeatCount (uint8_t cnt) {
     repeatcnt = cnt;
   }
@@ -96,12 +96,12 @@ public:
   }
 };
 
-template<class DeviceType,int DownChannel,int UpChannel>
+template<class DeviceType,int DownChannel,int UpChannel,encModes EncMode=ENCRES_1x,uint8_t delay=0>
 class RemoteEncoder : public BaseEncoder, public Alarm {
   int8_t last;
   DeviceType& sdev;
 public:
-  RemoteEncoder(DeviceType& d) : BaseEncoder(), Alarm(0), last(0), sdev(d) {}
+  RemoteEncoder(DeviceType& d) : BaseEncoder(), Alarm(0), last(0), sdev(d) {edgemode(EncMode); delaytime(delay);}
   virtual ~RemoteEncoder() {}
 
   void process () {


### PR DESCRIPTION
Extension of the encoder to half and quarter steps for encoders that have 2 or 4 detent positions per pulse period.
The configuration takes place when the class instance is created using the constructor. The new parameters are optional, so existing code can continue to be used unchanged.

A special feature emerged with double or quadruple evaluation when using hardware debouncing of the encoder signals via RC element: If the interrupt release occurs during initialization immediately after the port mode has been defined, the capacitor is still empty and is charging. This leads to an unwanted detection of an alleged rotary movement. Therefore the interrupt release must be delayed. For the sake of simplicity, I used the delay() method here, since this is called only once during boot and only during setup.