### PR TITLE
added output of FSCAL1 to radio watchdog

### DIFF
--- a/Radio-CC1101.h
+++ b/Radio-CC1101.h
@@ -160,7 +160,7 @@ public:
     , f1(0x65), f0(0x6A) // set to defaults
 #endif
     {}
-
+	
   uint8_t interruptMode() {
     return 0; // FALLING
   };
@@ -206,7 +206,7 @@ public:
 #endif
     spi.strobe(CC1101_SRX);
   }
-
+  
   uint8_t reset() {
 
     // Strobe CSn low / high
@@ -447,7 +447,7 @@ public:
   uint8_t rssi () const {
     return rss;
   }
-
+  
   void flushrx () {
     spi.strobe(CC1101_SIDLE);
     spi.strobe(CC1101_SNOP);
@@ -564,10 +564,6 @@ protected:
 
   uint8_t getVCOvalue() {
     return spi.readReg(CC1101_VCO_VC_DAC, CC1101_STATUS);
-  }
-
-  uint8_t getFSCAL1value() {
-    return spi.readReg(CC1101_FSCAL1, CC1101_CONFIG);
   }
 
   void forceCal() {

--- a/Radio-CC1101.h
+++ b/Radio-CC1101.h
@@ -160,7 +160,7 @@ public:
     , f1(0x65), f0(0x6A) // set to defaults
 #endif
     {}
-	
+
   uint8_t interruptMode() {
     return 0; // FALLING
   };
@@ -206,7 +206,7 @@ public:
 #endif
     spi.strobe(CC1101_SRX);
   }
-  
+
   uint8_t reset() {
 
     // Strobe CSn low / high
@@ -447,7 +447,7 @@ public:
   uint8_t rssi () const {
     return rss;
   }
-  
+
   void flushrx () {
     spi.strobe(CC1101_SIDLE);
     spi.strobe(CC1101_SNOP);
@@ -564,6 +564,10 @@ protected:
 
   uint8_t getVCOvalue() {
     return spi.readReg(CC1101_VCO_VC_DAC, CC1101_STATUS);
+  }
+
+  uint8_t getFSCAL1value() {
+    return spi.readReg(CC1101_FSCAL1, CC1101_CONFIG);
   }
 
   void forceCal() {

--- a/Radio.h
+++ b/Radio.h
@@ -118,7 +118,7 @@ public:
     waitMiso();
     deselect();
   }
-  
+
   uint8_t strobe(uint8_t cmd) {
     select();                                     // select  radio module
     waitMiso();                                   // wait until MISO goes low
@@ -219,7 +219,7 @@ public:
     deselect();
     SPI.endTransaction();
   }
-  
+
   void waitMiso () {
 #ifdef ARDUINO_ARCH_STM32F1
     while(digitalRead(SPI.misoPin()));
@@ -331,7 +331,7 @@ class Radio : public HWRADIO {
   static void isr () {
     instance().handleInt();
   }
-  
+
 #ifdef RADIOWATCHDOG
   class RadioWd : public Alarm {
     Radio& rd;
@@ -346,7 +346,7 @@ class Radio : public HWRADIO {
       uint8_t rxbytes = rd.getRXbytes();
       if (rxbytes) {                // some bytes detected
         if (!armed) {               // bytes are new in the queue
-          armed = 1;                
+          armed = 1;
           //DPRINTLN(':');
           set(millis2ticks(50));
           clock.add(*this);         // wait 50ms to finish the receive and GDO0 can signalize
@@ -361,8 +361,12 @@ class Radio : public HWRADIO {
       // if CC1101 stops receiving, VCO_VC_DAC goes to 0xFF
       uint8_t vcoval = rd.getVCOvalue();
       if (vcoval == 0xFF) {
+        uint8_t fscal1val = rd.getFSCAL1value();
+        DPRINT(F("FSCAL1 before forced calib: ")); DHEXLN(fscal1val);
         rd.forceCal();
-        DPRINT(F("\n\ncalibration forced... - ")); DPRINTLN(millis()); DPRINT('\n');
+        DPRINT(F("\n\ncalibration forced... - ")); DPRINTLN(millis());
+        fscal1val = rd.getFSCAL1value();
+        DPRINT(F("FSCAL1 after forced calib:  ")); DHEXLN(fscal1val);
       }
       // start the next timer cycle
       set(millis2ticks(500));       // 500ms polling
@@ -439,7 +443,7 @@ public:
 public:   //---------------------------------------------------------------------------------------------------------
   Radio () : state(ALIVE)
 #ifdef RADIOWATCHDOG
-    , radiowd(*this) 
+    , radiowd(*this)
 #endif
     {}
 
@@ -534,11 +538,11 @@ void disable () {
 
   // read the message form the internal buffer, if any
   uint8_t read (Message& msg) {
-    
+
     if( isState(READ) == false )
     //if (getGDO0falling() == false)
       return 0;
-    
+
     //if (isState(READ) == false) then DPRINTLN(F("interrupt overseen"));
 
     unsetState(READ);

--- a/Radio.h
+++ b/Radio.h
@@ -118,7 +118,7 @@ public:
     waitMiso();
     deselect();
   }
-
+  
   uint8_t strobe(uint8_t cmd) {
     select();                                     // select  radio module
     waitMiso();                                   // wait until MISO goes low
@@ -219,7 +219,7 @@ public:
     deselect();
     SPI.endTransaction();
   }
-
+  
   void waitMiso () {
 #ifdef ARDUINO_ARCH_STM32F1
     while(digitalRead(SPI.misoPin()));
@@ -331,7 +331,7 @@ class Radio : public HWRADIO {
   static void isr () {
     instance().handleInt();
   }
-
+  
 #ifdef RADIOWATCHDOG
   class RadioWd : public Alarm {
     Radio& rd;
@@ -346,7 +346,7 @@ class Radio : public HWRADIO {
       uint8_t rxbytes = rd.getRXbytes();
       if (rxbytes) {                // some bytes detected
         if (!armed) {               // bytes are new in the queue
-          armed = 1;
+          armed = 1;                
           //DPRINTLN(':');
           set(millis2ticks(50));
           clock.add(*this);         // wait 50ms to finish the receive and GDO0 can signalize
@@ -361,12 +361,8 @@ class Radio : public HWRADIO {
       // if CC1101 stops receiving, VCO_VC_DAC goes to 0xFF
       uint8_t vcoval = rd.getVCOvalue();
       if (vcoval == 0xFF) {
-        uint8_t fscal1val = rd.getFSCAL1value();
-        DPRINT(F("FSCAL1 before forced calib: ")); DHEXLN(fscal1val);
         rd.forceCal();
-        DPRINT(F("\n\ncalibration forced... - ")); DPRINTLN(millis());
-        fscal1val = rd.getFSCAL1value();
-        DPRINT(F("FSCAL1 after forced calib:  ")); DHEXLN(fscal1val);
+        DPRINT(F("\n\ncalibration forced... - ")); DPRINTLN(millis()); DPRINT('\n');
       }
       // start the next timer cycle
       set(millis2ticks(500));       // 500ms polling
@@ -443,7 +439,7 @@ public:
 public:   //---------------------------------------------------------------------------------------------------------
   Radio () : state(ALIVE)
 #ifdef RADIOWATCHDOG
-    , radiowd(*this)
+    , radiowd(*this) 
 #endif
     {}
 
@@ -538,11 +534,11 @@ void disable () {
 
   // read the message form the internal buffer, if any
   uint8_t read (Message& msg) {
-
+    
     if( isState(READ) == false )
     //if (getGDO0falling() == false)
       return 0;
-
+    
     //if (isState(READ) == false) then DPRINTLN(F("interrupt overseen"));
 
     unsetState(READ);


### PR DESCRIPTION
if VCO_VC_DAC becomes 0xFF, the values of FSCAL1 before and after forced recalib are output to determine if PLL was out of lock before recalib (value = 0x3F) and locked thereafter (value != 0x3F)